### PR TITLE
Crear MVP web para gestión de auditorías

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Auditoría MVP
+
+Aplicación web minimalista para gestionar auditorías internas y externas. Construida con FastAPI, SQLite y Bootstrap.
+
+## Características
+
+- Gestión de usuarios y roles (Administrador, Auditor, Cliente/Área auditada).
+- Creación y seguimiento de auditorías con checklist, actividades y responsables.
+- Registro de hallazgos con criticidad, evidencia adjunta y estados.
+- Planes de acción con responsables, fechas compromiso y seguimiento de cumplimiento.
+- Reportes básicos: dashboard, auditorías por estado, exportación de hallazgos a CSV y PDF.
+
+## Requisitos
+
+- Python 3.10+
+
+Instala las dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Ejecución
+
+Inicia el servidor de desarrollo:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Visita `http://localhost:8000`. Usuario administrador por defecto:
+
+- **Usuario:** `admin`
+- **Contraseña:** `admin`
+
+## Estructura de la base de datos
+
+La aplicación utiliza SQLite por defecto y crea el archivo `auditoria.db` automáticamente. Se generan las tablas necesarias para usuarios, auditorías, checklist, actividades, hallazgos y planes de acción.
+
+## Notas
+
+- Los archivos de evidencia se almacenan en `app/static/evidence`.
+- Las exportaciones se generan en `app/static` para ser descargadas.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,583 @@
+from __future__ import annotations
+
+import os
+import secrets
+from datetime import date, datetime
+from pathlib import Path
+from typing import Optional
+
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    Form,
+    HTTPException,
+    Request,
+    UploadFile,
+)
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from passlib.context import CryptContext
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String, Text, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session, relationship, sessionmaker
+from starlette.middleware.sessions import SessionMiddleware
+
+
+BASE_DIR = Path(__file__).resolve().parent
+DATABASE_URL = f"sqlite:///{BASE_DIR / 'auditoria.db'}"
+EVIDENCE_DIR = BASE_DIR / "static" / "evidence"
+EVIDENCE_DIR.mkdir(parents=True, exist_ok=True)
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+Base = declarative_base()
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class RoleEnum(str):
+    ADMIN = "admin"
+    AUDITOR = "auditor"
+    CLIENT = "client"
+
+
+class AuditStatus(str):
+    PLANNED = "planificada"
+    IN_PROGRESS = "en_curso"
+    CLOSED = "cerrada"
+
+
+class AuditType(str):
+    INTERNAL = "interna"
+    EXTERNAL = "externa"
+
+
+class FindingStatus(str):
+    OPEN = "abierto"
+    ACTION_PLAN = "plan_accion"
+    CLOSED = "cerrado"
+
+
+class ActionPlanStatus(str):
+    OPEN = "pendiente"
+    IN_PROGRESS = "en_progreso"
+    CLOSED = "cerrado"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(50), unique=True, index=True, nullable=False)
+    full_name = Column(String(100), nullable=False)
+    password_hash = Column(String(255), nullable=False)
+    role = Column(String(20), nullable=False, default=RoleEnum.CLIENT)
+
+    created_audits = relationship("Audit", back_populates="responsible", foreign_keys="Audit.responsible_id")
+
+
+class Audit(Base):
+    __tablename__ = "audits"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(150), nullable=False)
+    description = Column(Text, nullable=True)
+    audit_type = Column(String(20), nullable=False, default=AuditType.INTERNAL)
+    start_date = Column(Date, nullable=True)
+    end_date = Column(Date, nullable=True)
+    status = Column(String(20), nullable=False, default=AuditStatus.PLANNED)
+    responsible_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+
+    responsible = relationship("User", back_populates="created_audits", foreign_keys=[responsible_id])
+    checklist_items = relationship("ChecklistItem", cascade="all, delete-orphan", back_populates="audit")
+    activities = relationship("AuditActivity", cascade="all, delete-orphan", back_populates="audit")
+    findings = relationship("Finding", cascade="all, delete-orphan", back_populates="audit")
+
+
+class ChecklistItem(Base):
+    __tablename__ = "checklist_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    audit_id = Column(Integer, ForeignKey("audits.id"))
+    description = Column(Text, nullable=False)
+    status = Column(String(20), nullable=False, default="pendiente")
+
+    audit = relationship("Audit", back_populates="checklist_items")
+
+
+class AuditActivity(Base):
+    __tablename__ = "audit_activities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    audit_id = Column(Integer, ForeignKey("audits.id"))
+    activity_date = Column(Date, nullable=False)
+    activity_type = Column(String(20), nullable=False)  # visita, entrevista, documento
+    notes = Column(Text, nullable=True)
+
+    audit = relationship("Audit", back_populates="activities")
+
+
+class Finding(Base):
+    __tablename__ = "findings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    audit_id = Column(Integer, ForeignKey("audits.id"))
+    category = Column(String(100), nullable=False)
+    description = Column(Text, nullable=False)
+    severity = Column(String(20), nullable=False)
+    status = Column(String(20), nullable=False, default=FindingStatus.OPEN)
+    evidence_file = Column(String(255), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    audit = relationship("Audit", back_populates="findings")
+    action_plans = relationship("ActionPlan", cascade="all, delete-orphan", back_populates="finding")
+
+
+class ActionPlan(Base):
+    __tablename__ = "action_plans"
+
+    id = Column(Integer, primary_key=True, index=True)
+    finding_id = Column(Integer, ForeignKey("findings.id"))
+    description = Column(Text, nullable=False)
+    responsible = Column(String(150), nullable=False)
+    due_date = Column(Date, nullable=True)
+    status = Column(String(20), nullable=False, default=ActionPlanStatus.OPEN)
+
+    finding = relationship("Finding", back_populates="action_plans")
+
+
+app = FastAPI(title="Auditoria MVP")
+app.add_middleware(SessionMiddleware, secret_key=os.environ.get("SESSION_SECRET", secrets.token_hex(16)))
+app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+
+# Dependency
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def create_default_users(db: Session) -> None:
+    if not db.query(User).filter_by(username="admin").first():
+        admin = User(
+            username="admin",
+            full_name="Administrador",
+            password_hash=pwd_context.hash("admin"),
+            role=RoleEnum.ADMIN,
+        )
+        db.add(admin)
+        db.commit()
+
+
+@app.on_event("startup")
+def startup_event() -> None:
+    Base.metadata.create_all(bind=engine)
+    with SessionLocal() as db:
+        create_default_users(db)
+
+
+# Authentication helpers
+
+def get_current_user(request: Request, db: Session = Depends(get_db)) -> User:
+    user_id = request.session.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="No autenticado")
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=401, detail="Usuario no encontrado")
+    return user
+
+
+@app.get("/login", response_class=HTMLResponse)
+def login_form(request: Request):
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.post("/login")
+def login(
+    request: Request,
+    username: str = Form(...),
+    password: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    user = db.query(User).filter_by(username=username).first()
+    if not user or not pwd_context.verify(password, user.password_hash):
+        return templates.TemplateResponse(
+            "login.html",
+            {"request": request, "error": "Credenciales inválidas"},
+            status_code=400,
+        )
+    request.session["user_id"] = user.id
+    response = RedirectResponse("/", status_code=303)
+    return response
+
+
+@app.get("/logout")
+def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse("/login", status_code=303)
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard(request: Request, db: Session = Depends(get_db)):
+    user = get_current_user(request, db)
+    total_audits = db.query(Audit).count()
+    open_findings = db.query(Finding).filter(Finding.status != FindingStatus.CLOSED).count()
+    closed_findings = db.query(Finding).filter(Finding.status == FindingStatus.CLOSED).count()
+    audits_in_progress = db.query(Audit).filter(Audit.status == AuditStatus.IN_PROGRESS).count()
+    audits_closed = db.query(Audit).filter(Audit.status == AuditStatus.CLOSED).count()
+
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {
+            "request": request,
+            "user": user,
+            "total_audits": total_audits,
+            "open_findings": open_findings,
+            "closed_findings": closed_findings,
+            "audits_in_progress": audits_in_progress,
+            "audits_closed": audits_closed,
+        },
+    )
+
+
+@app.get("/users", response_class=HTMLResponse)
+def list_users(request: Request, db: Session = Depends(get_db)):
+    user = get_current_user(request, db)
+    if user.role != RoleEnum.ADMIN:
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+    users = db.query(User).all()
+    return templates.TemplateResponse("users.html", {"request": request, "user": user, "users": users})
+
+
+@app.post("/users")
+def create_user(
+    request: Request,
+    username: str = Form(...),
+    full_name: str = Form(...),
+    role: str = Form(...),
+    password: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    current = get_current_user(request, db)
+    if current.role != RoleEnum.ADMIN:
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+    if db.query(User).filter_by(username=username).first():
+        raise HTTPException(status_code=400, detail="El usuario ya existe")
+    new_user = User(
+        username=username,
+        full_name=full_name,
+        role=role,
+        password_hash=pwd_context.hash(password),
+    )
+    db.add(new_user)
+    db.commit()
+    return RedirectResponse("/users", status_code=303)
+
+
+@app.get("/audits", response_class=HTMLResponse)
+def audits_list(request: Request, db: Session = Depends(get_db)):
+    user = get_current_user(request, db)
+    audits = db.query(Audit).order_by(Audit.start_date.desc().nullslast()).all()
+    auditors = db.query(User).filter(User.role == RoleEnum.AUDITOR).all()
+    return templates.TemplateResponse(
+        "audits_list.html",
+        {"request": request, "user": user, "audits": audits, "auditors": auditors, "statuses": AuditStatus.__dict__},
+    )
+
+
+@app.post("/audits")
+def create_audit(
+    request: Request,
+    name: str = Form(...),
+    description: str = Form("") ,
+    audit_type: str = Form(...),
+    start_date: Optional[date] = Form(None),
+    end_date: Optional[date] = Form(None),
+    responsible_id: Optional[int] = Form(None),
+    db: Session = Depends(get_db),
+):
+    user = get_current_user(request, db)
+    if user.role not in (RoleEnum.ADMIN, RoleEnum.AUDITOR):
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+    audit = Audit(
+        name=name,
+        description=description,
+        audit_type=audit_type,
+        start_date=start_date,
+        end_date=end_date,
+        responsible_id=responsible_id,
+        status=AuditStatus.PLANNED,
+    )
+    db.add(audit)
+    db.commit()
+    return RedirectResponse("/audits", status_code=303)
+
+
+@app.post("/audits/{audit_id}/status")
+def update_audit_status(
+    request: Request,
+    audit_id: int,
+    status: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    user = get_current_user(request, db)
+    if user.role not in (RoleEnum.ADMIN, RoleEnum.AUDITOR):
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+    audit = db.query(Audit).get(audit_id)
+    if not audit:
+        raise HTTPException(status_code=404, detail="Auditoría no encontrada")
+    audit.status = status
+    db.commit()
+    return RedirectResponse(f"/audits/{audit_id}", status_code=303)
+
+
+@app.get("/audits/{audit_id}", response_class=HTMLResponse)
+def audit_detail(audit_id: int, request: Request, db: Session = Depends(get_db)):
+    user = get_current_user(request, db)
+    audit = db.query(Audit).get(audit_id)
+    if not audit:
+        raise HTTPException(status_code=404, detail="Auditoría no encontrada")
+    return templates.TemplateResponse(
+        "audit_detail.html",
+        {
+            "request": request,
+            "user": user,
+            "audit": audit,
+            "statuses": {
+                "finding": FindingStatus.__dict__,
+                "plan": ActionPlanStatus.__dict__,
+                "audit": AuditStatus.__dict__,
+            },
+        },
+    )
+
+
+@app.post("/audits/{audit_id}/checklist")
+def add_checklist_item(
+    request: Request,
+    audit_id: int,
+    description: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    user = get_current_user(request, db)
+    if user.role not in (RoleEnum.ADMIN, RoleEnum.AUDITOR):
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+    audit = db.query(Audit).get(audit_id)
+    if not audit:
+        raise HTTPException(status_code=404, detail="Auditoría no encontrada")
+    item = ChecklistItem(audit_id=audit_id, description=description)
+    db.add(item)
+    db.commit()
+    return RedirectResponse(f"/audits/{audit_id}", status_code=303)
+
+
+@app.post("/audits/{audit_id}/activities")
+def add_activity(
+    request: Request,
+    audit_id: int,
+    activity_date: date = Form(...),
+    activity_type: str = Form(...),
+    notes: str = Form("") ,
+    db: Session = Depends(get_db),
+):
+    user = get_current_user(request, db)
+    if user.role not in (RoleEnum.ADMIN, RoleEnum.AUDITOR):
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+    activity = AuditActivity(
+        audit_id=audit_id,
+        activity_date=activity_date,
+        activity_type=activity_type,
+        notes=notes,
+    )
+    db.add(activity)
+    db.commit()
+    return RedirectResponse(f"/audits/{audit_id}", status_code=303)
+
+
+@app.post("/audits/{audit_id}/findings")
+def add_finding(
+    request: Request,
+    audit_id: int,
+    category: str = Form(...),
+    description: str = Form(...),
+    severity: str = Form(...),
+    status: str = Form(FindingStatus.OPEN),
+    evidence: Optional[UploadFile] = File(None),
+    db: Session = Depends(get_db),
+):
+    user = get_current_user(request, db)
+    if user.role not in (RoleEnum.ADMIN, RoleEnum.AUDITOR):
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+
+    evidence_path: Optional[str] = None
+    if evidence and evidence.filename:
+        ext = Path(evidence.filename).suffix
+        unique_name = f"{datetime.utcnow().strftime('%Y%m%d%H%M%S')}_{secrets.token_hex(4)}{ext}"
+        save_path = EVIDENCE_DIR / unique_name
+        with save_path.open("wb") as buffer:
+            buffer.write(evidence.file.read())
+        evidence_path = f"/static/evidence/{unique_name}"
+
+    finding = Finding(
+        audit_id=audit_id,
+        category=category,
+        description=description,
+        severity=severity,
+        status=status,
+        evidence_file=evidence_path,
+    )
+    db.add(finding)
+    db.commit()
+    return RedirectResponse(f"/audits/{audit_id}", status_code=303)
+
+
+@app.post("/findings/{finding_id}/status")
+def update_finding_status(
+    request: Request,
+    finding_id: int,
+    status: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    user = get_current_user(request, db)
+    if user.role not in (RoleEnum.ADMIN, RoleEnum.AUDITOR):
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+    finding = db.query(Finding).get(finding_id)
+    if not finding:
+        raise HTTPException(status_code=404, detail="Hallazgo no encontrado")
+    finding.status = status
+    db.commit()
+    return RedirectResponse(f"/audits/{finding.audit_id}", status_code=303)
+
+
+@app.post("/findings/{finding_id}/action_plans")
+def add_action_plan(
+    request: Request,
+    finding_id: int,
+    description: str = Form(...),
+    responsible: str = Form(...),
+    due_date: Optional[date] = Form(None),
+    db: Session = Depends(get_db),
+):
+    user = get_current_user(request, db)
+    if user.role not in (RoleEnum.ADMIN, RoleEnum.AUDITOR, RoleEnum.CLIENT):
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+    finding = db.query(Finding).get(finding_id)
+    if not finding:
+        raise HTTPException(status_code=404, detail="Hallazgo no encontrado")
+    action_plan = ActionPlan(
+        finding_id=finding_id,
+        description=description,
+        responsible=responsible,
+        due_date=due_date,
+    )
+    db.add(action_plan)
+    db.commit()
+    return RedirectResponse(f"/audits/{finding.audit_id}", status_code=303)
+
+
+@app.post("/action_plans/{plan_id}/status")
+def update_action_plan_status(
+    request: Request,
+    plan_id: int,
+    status: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    user = get_current_user(request, db)
+    plan = db.query(ActionPlan).get(plan_id)
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan no encontrado")
+    if user.role not in (RoleEnum.ADMIN, RoleEnum.AUDITOR, RoleEnum.CLIENT):
+        raise HTTPException(status_code=403, detail="Acceso no autorizado")
+    plan.status = status
+    db.commit()
+    return RedirectResponse(f"/audits/{plan.finding.audit_id}", status_code=303)
+
+
+@app.get("/reports", response_class=HTMLResponse)
+def reports_home(request: Request, db: Session = Depends(get_db)):
+    user = get_current_user(request, db)
+    audits = db.query(Audit).all()
+    return templates.TemplateResponse("reports.html", {"request": request, "user": user, "audits": audits})
+
+
+@app.get("/reports/audits/{status}")
+def audits_by_status(status: str, request: Request, db: Session = Depends(get_db)):
+    user = get_current_user(request, db)
+    audits = db.query(Audit).filter(Audit.status == status).all()
+    return templates.TemplateResponse(
+        "audits_by_status.html",
+        {"request": request, "user": user, "audits": audits, "status": status},
+    )
+
+
+@app.get("/reports/findings/csv")
+def export_findings_csv(db: Session = Depends(get_db)):
+    import pandas as pd
+
+    findings = (
+        db.query(Finding)
+        .join(Audit)
+        .with_entities(
+            Audit.name.label("auditoria"),
+            Finding.category,
+            Finding.description,
+            Finding.severity,
+            Finding.status,
+            Finding.created_at,
+        )
+        .all()
+    )
+
+    df = pd.DataFrame(findings, columns=["auditoria", "categoria", "descripcion", "criticidad", "estado", "creado"])
+    csv_path = BASE_DIR / "static" / "hallazgos.csv"
+    df.to_csv(csv_path, index=False)
+    return FileResponse(csv_path, filename="hallazgos.csv")
+
+
+@app.get("/reports/findings/pdf")
+def export_findings_pdf(db: Session = Depends(get_db)):
+    from fpdf import FPDF
+
+    pdf_path = BASE_DIR / "static" / "hallazgos.pdf"
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", "B", 16)
+    pdf.cell(0, 10, "Reporte de Hallazgos", ln=True, align="C")
+    pdf.ln(5)
+    pdf.set_font("Arial", size=10)
+
+    findings = db.query(Finding).join(Audit).with_entities(Audit.name, Finding.category, Finding.description, Finding.severity, Finding.status).all()
+    for audit_name, category, description, severity, status in findings:
+        pdf.set_font("Arial", "B", 10)
+        pdf.multi_cell(0, 6, f"Auditoría: {audit_name} | Categoría: {category} | Criticidad: {severity} | Estado: {status}")
+        pdf.set_font("Arial", size=9)
+        pdf.multi_cell(0, 5, f"Descripción: {description}")
+        pdf.ln(2)
+
+    pdf.output(str(pdf_path))
+    return FileResponse(pdf_path, filename="hallazgos.pdf")
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    if exc.status_code == 401:
+        return RedirectResponse("/login", status_code=303)
+    return templates.TemplateResponse(
+        "error.html",
+        {"request": request, "status_code": exc.status_code, "detail": exc.detail},
+        status_code=exc.status_code,
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/app/templates/audit_detail.html
+++ b/app/templates/audit_detail.html
@@ -1,0 +1,216 @@
+{% extends "base.html" %}
+{% block title %}Auditoría {{ audit.name }}{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+        <h1>{{ audit.name }}</h1>
+        <p class="text-muted">Tipo: {{ audit.audit_type }} | Estado: {{ audit.status }}</p>
+    </div>
+    {% if user.role in ['admin', 'auditor'] %}
+    <form method="post" action="/audits/{{ audit.id }}/status" class="d-flex gap-2">
+        <select name="status" class="form-select">
+            <option value="planificada" {% if audit.status == 'planificada' %}selected{% endif %}>Planificada</option>
+            <option value="en_curso" {% if audit.status == 'en_curso' %}selected{% endif %}>En curso</option>
+            <option value="cerrada" {% if audit.status == 'cerrada' %}selected{% endif %}>Cerrada</option>
+        </select>
+        <button class="btn btn-primary" type="submit">Actualizar</button>
+    </form>
+    {% endif %}
+</div>
+<div class="row g-4">
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-header">Checklist</div>
+            <div class="card-body">
+                <ul class="list-group mb-3">
+                    {% for item in audit.checklist_items %}
+                        <li class="list-group-item">{{ item.description }}</li>
+                    {% else %}
+                        <li class="list-group-item">Sin criterios cargados</li>
+                    {% endfor %}
+                </ul>
+                {% if user.role in ['admin', 'auditor'] %}
+                <form method="post" action="/audits/{{ audit.id }}/checklist">
+                    <div class="mb-2">
+                        <label class="form-label">Nuevo criterio</label>
+                        <textarea class="form-control" name="description" required></textarea>
+                    </div>
+                    <button class="btn btn-outline-primary btn-sm" type="submit">Agregar</button>
+                </form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-header">Actividades</div>
+            <div class="card-body">
+                <ul class="list-group mb-3">
+                    {% for activity in audit.activities %}
+                        <li class="list-group-item">
+                            <strong>{{ activity.activity_date }}</strong> - {{ activity.activity_type }}<br>
+                            <small>{{ activity.notes }}</small>
+                        </li>
+                    {% else %}
+                        <li class="list-group-item">Sin actividades registradas</li>
+                    {% endfor %}
+                </ul>
+                {% if user.role in ['admin', 'auditor'] %}
+                <form method="post" action="/audits/{{ audit.id }}/activities">
+                    <div class="mb-2">
+                        <label class="form-label">Fecha</label>
+                        <input type="date" class="form-control" name="activity_date" required>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">Tipo</label>
+                        <select class="form-select" name="activity_type">
+                            <option value="visita">Visita</option>
+                            <option value="entrevista">Entrevista</option>
+                            <option value="documento">Documento revisado</option>
+                        </select>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">Notas</label>
+                        <textarea class="form-control" name="notes"></textarea>
+                    </div>
+                    <button class="btn btn-outline-primary btn-sm" type="submit">Registrar</button>
+                </form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-header">Datos generales</div>
+            <div class="card-body">
+                <p><strong>Responsable:</strong> {{ audit.responsible.full_name if audit.responsible else 'Sin asignar' }}</p>
+                <p><strong>Inicio:</strong> {{ audit.start_date or '-' }}</p>
+                <p><strong>Fin:</strong> {{ audit.end_date or '-' }}</p>
+                <p><strong>Descripción:</strong><br>{{ audit.description or 'Sin descripción' }}</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="mt-4">
+    <h2>Hallazgos y planes de acción</h2>
+    {% if user.role in ['admin', 'auditor'] %}
+    <div class="card mb-3">
+        <div class="card-body">
+            <h5>Registrar hallazgo</h5>
+            <form method="post" action="/audits/{{ audit.id }}/findings" enctype="multipart/form-data">
+                <div class="row g-2">
+                    <div class="col-md-3">
+                        <label class="form-label">Categoría</label>
+                        <input class="form-control" type="text" name="category" required>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">Criticidad</label>
+                        <select class="form-select" name="severity">
+                            <option value="alta">Alta</option>
+                            <option value="media">Media</option>
+                            <option value="baja">Baja</option>
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">Estado</label>
+                        <select class="form-select" name="status">
+                            <option value="abierto">Abierto</option>
+                            <option value="plan_accion">En plan de acción</option>
+                            <option value="cerrado">Cerrado</option>
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">Evidencia</label>
+                        <input class="form-control" type="file" name="evidence">
+                    </div>
+                </div>
+                <div class="mt-2">
+                    <label class="form-label">Descripción</label>
+                    <textarea class="form-control" name="description" required></textarea>
+                </div>
+                <button class="btn btn-primary mt-3" type="submit">Guardar hallazgo</button>
+            </form>
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="accordion" id="findingsAccordion">
+        {% for finding in audit.findings %}
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading{{ finding.id }}">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ finding.id }}">
+                    {{ finding.category }} - {{ finding.severity }} - Estado: {{ finding.status }}
+                </button>
+            </h2>
+            <div id="collapse{{ finding.id }}" class="accordion-collapse collapse" data-bs-parent="#findingsAccordion">
+                <div class="accordion-body">
+                    <p>{{ finding.description }}</p>
+                    {% if finding.evidence_file %}
+                        <p><a href="{{ finding.evidence_file }}" target="_blank">Ver evidencia</a></p>
+                    {% endif %}
+                    {% if user.role in ['admin', 'auditor'] %}
+                    <form class="mb-3" method="post" action="/findings/{{ finding.id }}/status">
+                        <label class="form-label">Actualizar estado</label>
+                        <div class="input-group">
+                            <select class="form-select" name="status">
+                                <option value="abierto" {% if finding.status == 'abierto' %}selected{% endif %}>Abierto</option>
+                                <option value="plan_accion" {% if finding.status == 'plan_accion' %}selected{% endif %}>En plan de acción</option>
+                                <option value="cerrado" {% if finding.status == 'cerrado' %}selected{% endif %}>Cerrado</option>
+                            </select>
+                            <button class="btn btn-outline-primary" type="submit">Actualizar</button>
+                        </div>
+                    </form>
+                    {% endif %}
+                    <h5>Planes de acción</h5>
+                    <ul class="list-group mb-3">
+                        {% for plan in finding.action_plans %}
+                            <li class="list-group-item">
+                                <strong>{{ plan.description }}</strong><br>
+                                Responsable: {{ plan.responsible }} | Compromiso: {{ plan.due_date or '-' }} | Estado: {{ plan.status }}
+                                {% if user.role in ['admin', 'auditor', 'client'] %}
+                                <form class="mt-2" method="post" action="/action_plans/{{ plan.id }}/status">
+                                    <div class="input-group input-group-sm">
+                                        <select class="form-select" name="status">
+                                            <option value="pendiente" {% if plan.status == 'pendiente' %}selected{% endif %}>Pendiente</option>
+                                            <option value="en_progreso" {% if plan.status == 'en_progreso' %}selected{% endif %}>En progreso</option>
+                                            <option value="cerrado" {% if plan.status == 'cerrado' %}selected{% endif %}>Cerrado</option>
+                                        </select>
+                                        <button class="btn btn-outline-success" type="submit">Actualizar</button>
+                                    </div>
+                                </form>
+                                {% endif %}
+                            </li>
+                        {% else %}
+                            <li class="list-group-item">Sin planes registrados</li>
+                        {% endfor %}
+                    </ul>
+                    <div class="card card-body">
+                        <h6>Agregar plan de acción</h6>
+                        <form method="post" action="/findings/{{ finding.id }}/action_plans">
+                            <div class="row g-2">
+                                <div class="col-md-6">
+                                    <label class="form-label">Responsable</label>
+                                    <input class="form-control" type="text" name="responsible" required>
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">Fecha compromiso</label>
+                                    <input class="form-control" type="date" name="due_date">
+                                </div>
+                            </div>
+                            <div class="mt-2">
+                                <label class="form-label">Acción correctiva</label>
+                                <textarea class="form-control" name="description" required></textarea>
+                            </div>
+                            <button class="btn btn-outline-primary btn-sm mt-2" type="submit">Agregar</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% else %}
+            <p class="text-muted">No hay hallazgos registrados.</p>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/audits_by_status.html
+++ b/app/templates/audits_by_status.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Auditorías{% endblock %}
+{% block content %}
+<h1 class="mb-3">Auditorías en estado: {{ status }}</h1>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th>Tipo</th>
+            <th>Inicio</th>
+            <th>Fin</th>
+            <th>Responsable</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for audit in audits %}
+        <tr>
+            <td>{{ audit.name }}</td>
+            <td>{{ audit.audit_type }}</td>
+            <td>{{ audit.start_date or '-' }}</td>
+            <td>{{ audit.end_date or '-' }}</td>
+            <td>{{ audit.responsible.full_name if audit.responsible else '-' }}</td>
+        </tr>
+    {% else %}
+        <tr><td colspan="5">No hay auditorías en este estado.</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/app/templates/audits_list.html
+++ b/app/templates/audits_list.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+{% block title %}Auditorías{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>Auditorías</h1>
+    {% if user.role in ['admin', 'auditor'] %}
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#newAuditModal">Nueva auditoría</button>
+    {% endif %}
+</div>
+<table class="table table-hover">
+    <thead>
+    <tr>
+        <th>Nombre</th>
+        <th>Tipo</th>
+        <th>Inicio</th>
+        <th>Fin</th>
+        <th>Estado</th>
+        <th>Responsable</th>
+        <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for audit in audits %}
+        <tr>
+            <td>{{ audit.name }}</td>
+            <td>{{ audit.audit_type }}</td>
+            <td>{{ audit.start_date or '-' }}</td>
+            <td>{{ audit.end_date or '-' }}</td>
+            <td>{{ audit.status }}</td>
+            <td>{{ audit.responsible.full_name if audit.responsible else '-' }}</td>
+            <td><a class="btn btn-sm btn-outline-primary" href="/audits/{{ audit.id }}">Ver</a></td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+<div class="modal fade" id="newAuditModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Crear auditoría</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form method="post" action="/audits">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Nombre</label>
+                        <input type="text" class="form-control" name="name" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Descripción</label>
+                        <textarea class="form-control" name="description"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Tipo</label>
+                        <select class="form-select" name="audit_type">
+                            <option value="interna">Interna</option>
+                            <option value="externa">Externa</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <div class="col">
+                            <label class="form-label">Fecha inicio</label>
+                            <input type="date" class="form-control" name="start_date">
+                        </div>
+                        <div class="col">
+                            <label class="form-label">Fecha fin</label>
+                            <input type="date" class="form-control" name="end_date">
+                        </div>
+                    </div>
+                    <div class="mt-3">
+                        <label class="form-label">Responsable</label>
+                        <select class="form-select" name="responsible_id">
+                            <option value="">Sin asignar</option>
+                            {% for auditor in auditors %}
+                                <option value="{{ auditor.id }}">{{ auditor.full_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-primary">Guardar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Auditorías{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">Auditorías</a>
+        <div class="collapse navbar-collapse">
+            <ul class="navbar-nav me-auto">
+                <li class="nav-item"><a class="nav-link" href="/audits">Auditorías</a></li>
+                <li class="nav-item"><a class="nav-link" href="/reports">Reportes</a></li>
+                {% if user and user.role == 'admin' %}
+                    <li class="nav-item"><a class="nav-link" href="/users">Usuarios</a></li>
+                {% endif %}
+            </ul>
+            <span class="navbar-text me-3">{{ user.full_name if user else '' }}</span>
+            <a class="btn btn-outline-light" href="/logout">Cerrar sesión</a>
+        </div>
+    </div>
+</nav>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<div class="row g-3">
+    <div class="col-md-3">
+        <div class="card text-bg-primary">
+            <div class="card-body">
+                <h5>Total Auditorías</h5>
+                <p class="display-6">{{ total_audits }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-bg-warning">
+            <div class="card-body">
+                <h5>Hallazgos abiertos</h5>
+                <p class="display-6">{{ open_findings }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-bg-success">
+            <div class="card-body">
+                <h5>Hallazgos cerrados</h5>
+                <p class="display-6">{{ closed_findings }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-bg-info">
+            <div class="card-body">
+                <h5>Auditorías en curso</h5>
+                <p class="display-6">{{ audits_in_progress }}</p>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="mt-4">
+    <a class="btn btn-outline-primary" href="/audits">Ver auditorías</a>
+    <a class="btn btn-outline-secondary" href="/reports">Ver reportes</a>
+</div>
+{% endblock %}

--- a/app/templates/error.html
+++ b/app/templates/error.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}Error{% endblock %}
+{% block content %}
+<div class="alert alert-danger">
+    <h4>Error {{ status_code }}</h4>
+    <p>{{ detail }}</p>
+</div>
+<a href="/" class="btn btn-primary">Volver al inicio</a>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Iniciar sesión</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light d-flex align-items-center" style="height:100vh;">
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-4">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h2 class="card-title text-center mb-4">Auditorías</h2>
+                    {% if error %}
+                        <div class="alert alert-danger">{{ error }}</div>
+                    {% endif %}
+                    <form method="post" action="/login">
+                        <div class="mb-3">
+                            <label class="form-label">Usuario</label>
+                            <input type="text" class="form-control" name="username" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Contraseña</label>
+                            <input type="password" class="form-control" name="password" required>
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">Ingresar</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/app/templates/reports.html
+++ b/app/templates/reports.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}Reportes{% endblock %}
+{% block content %}
+<h1 class="mb-4">Reportes</h1>
+<div class="row g-3">
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5>Auditorías</h5>
+                <p>Consulta el estado general de las auditorías.</p>
+                <div class="d-grid gap-2">
+                    <a class="btn btn-outline-primary" href="/reports/audits/en_curso">En curso</a>
+                    <a class="btn btn-outline-success" href="/reports/audits/cerrada">Cerradas</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5>Exportar hallazgos</h5>
+                <p>Descarga los hallazgos registrados para su análisis.</p>
+                <div class="d-grid gap-2">
+                    <a class="btn btn-outline-secondary" href="/reports/findings/csv">Descargar CSV</a>
+                    <a class="btn btn-outline-secondary" href="/reports/findings/pdf">Descargar PDF</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block title %}Usuarios{% endblock %}
+{% block content %}
+<h1 class="mb-4">Gestión de usuarios</h1>
+<div class="row">
+    <div class="col-md-6">
+        <h2>Usuarios existentes</h2>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Usuario</th>
+                    <th>Nombre</th>
+                    <th>Rol</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for item in users %}
+                <tr>
+                    <td>{{ item.username }}</td>
+                    <td>{{ item.full_name }}</td>
+                    <td>{{ item.role }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="col-md-6">
+        <h2>Crear nuevo usuario</h2>
+        <form method="post" action="/users">
+            <div class="mb-3">
+                <label class="form-label">Usuario</label>
+                <input class="form-control" type="text" name="username" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Nombre completo</label>
+                <input class="form-control" type="text" name="full_name" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Rol</label>
+                <select class="form-select" name="role" required>
+                    <option value="admin">Administrador</option>
+                    <option value="auditor">Auditor</option>
+                    <option value="client">Cliente/Área</option>
+                </select>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Contraseña</label>
+                <input class="form-control" type="password" name="password" required>
+            </div>
+            <button class="btn btn-primary" type="submit">Guardar</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+jinja2
+sqlalchemy
+passlib[bcrypt]
+python-multipart
+pandas
+fpdf2


### PR DESCRIPTION
## Resumen
- implementar backend FastAPI con SQLite para usuarios, auditorías, hallazgos y planes de acción
- agregar vistas con Bootstrap para login, dashboard, detalle de auditorías y reportes básicos
- habilitar exportación de hallazgos a CSV y PDF junto con carga de evidencias

## Pruebas
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d6dd64b8048331be437682cde904c8