### PR TITLE
docs: expand onboarding guidance in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 Suite full-stack para gestionar auditorías multi-proyecto con módulos especializados, RBAC por proyecto y exportables ejecutivos.
 
+## Índice
+
+1. [Arquitectura](#arquitectura)
+2. [Requisitos](#requisitos)
+3. [Configuración local](#configuración-local)
+4. [Docker](#docker)
+5. [Variables de entorno](#variables-de-entorno)
+6. [Usuarios demo](#usuarios-demo)
+7. [Módulos clave](#módulos-clave)
+8. [Scripts útiles](#scripts-útiles)
+9. [OpenAPI](#openapi)
+10. [Tests](#tests)
+11. [Seeds](#seeds)
+12. [Capturas](#capturas)
+
 ## Arquitectura
 
 ```
@@ -39,11 +54,23 @@ npm run dev
 
 La API corre en `http://localhost:4000/api` y el front en `http://localhost:5173`.
 
-### Docker
+## Docker
 
 ```bash
 docker-compose up --build
 ```
+
+## Variables de entorno
+
+Cada paquete incluye un archivo `.env.example` con los valores mínimos para iniciar el proyecto. Los más relevantes son:
+
+| Variable | Descripción | Paquete |
+| --- | --- | --- |
+| `DATABASE_URL` | Cadena de conexión a PostgreSQL utilizada por Prisma. | `api` |
+| `JWT_SECRET` | Clave de firma para los tokens JWT. | `api` |
+| `VITE_API_URL` | URL base de la API consumida por el front-end. | `web` |
+
+Recuerda copiar cada archivo `*.env.example` a `.env` y personalizarlo según tu entorno antes de iniciar los servicios.
 
 ## Usuarios demo
 
@@ -67,6 +94,22 @@ docker-compose up --build
 - KPIs y dashboard
 - Exportables Excel ZIP + PDF ejecutivo
 - Audit trail
+
+## Scripts útiles
+
+En cada paquete puedes apoyar el flujo de desarrollo con los siguientes comandos:
+
+```bash
+# API
+npm run lint       # Linting de la capa backend
+npm run test       # Ejecuta la suite de tests de la API
+
+# Web
+npm run lint       # Analiza el front-end con ESLint
+npm run test       # Ejecuta pruebas unitarias con Vitest
+```
+
+Los scripts comparten nombres entre paquetes para simplificar la experiencia de desarrollo.
 
 ## OpenAPI
 


### PR DESCRIPTION
## Summary
- add an index to the README for easier navigation
- document required environment variables for the API and web apps
- note the shared lint and test scripts available in each package

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d769ca69908331931644f9be2ebf73