### PR TITLE
Use tsx for Prisma seed execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ Suite full-stack para gestionar auditorías multi-proyecto con módulos especial
 2. [Requisitos](#requisitos)
 3. [Configuración local](#configuración-local)
 4. [Docker](#docker)
-5. [Variables de entorno](#variables-de-entorno)
-6. [Usuarios demo](#usuarios-demo)
-7. [Módulos clave](#módulos-clave)
-8. [Scripts útiles](#scripts-útiles)
-9. [OpenAPI](#openapi)
-10. [Tests](#tests)
-11. [Seeds](#seeds)
-12. [Capturas](#capturas)
+5. [Semilla de datos (Dev)](#semilla-de-datos-dev)
+6. [Variables de entorno](#variables-de-entorno)
+7. [Usuarios demo](#usuarios-demo)
+8. [Módulos clave](#módulos-clave)
+9. [Scripts útiles](#scripts-útiles)
+10. [OpenAPI](#openapi)
+11. [Tests](#tests)
+12. [Seeds](#seeds)
+13. [Capturas](#capturas)
 
 ## Arquitectura
 
@@ -63,8 +64,29 @@ curl http://localhost:4000/api/health
 ## Docker
 
 ```bash
-docker-compose up --build
+docker compose up -d --build
 ```
+
+## Semilla de datos (Dev)
+
+1. Levanta servicios:
+   ```bash
+   docker compose up -d --build
+   ```
+2. Aplica migraciones:
+   ```bash
+   docker compose exec api npm run migrate:deploy
+   ```
+3. Ejecuta seed:
+   ```bash
+   docker compose exec api npm run seed
+   ```
+
+Usuarios por defecto:
+
+- `admin@demo.com` / `Cambiar123!`
+- `consultor@demo.com` / `Cambiar123!`
+- `cliente@demo.com` / `Cambiar123!`
 
 ## Variables de entorno
 
@@ -82,9 +104,9 @@ Recuerda copiar cada archivo `*.env.example` a `.env` y personalizarlo según tu
 
 | Email | Rol | Contraseña |
 | --- | --- | --- |
-| admin@nustrial.com | Admin | admin123 |
-| consultor@nustrial.com | Consultor | consultor123 |
-| cliente@nustrial.com | Cliente | cliente123 |
+| admin@demo.com | Admin | Cambiar123! |
+| consultor@demo.com | Consultor | Cambiar123! |
+| cliente@demo.com | Cliente | Cambiar123! |
 
 ## Módulos clave
 
@@ -153,11 +175,11 @@ npm run test
 
 ## Seeds
 
-Ejecuta `npm run seed` en `api` para poblar la base con los proyectos demo:
+El seed `npm run seed` (o `docker compose exec api npm run seed`) crea:
 
-- **Nutrial – Auditoría 2025** con Recepción/Picking/Despacho habilitados.
-- **Nutrial – Diagnóstico Express** sin features de procesos activadas (ideal para validar UI condicional).
-- **DemoCorp – Levantamiento Inicial** asociado a una segunda empresa demo con feature `dispatch` activo.
+- Empresas demo **Nutrial** y **DemoCorp**.
+- Usuarios `admin@demo.com`, `consultor@demo.com` y `cliente@demo.com` con contraseña `Cambiar123!`.
+- Proyecto **Nutrial – Auditoría 2025** con `settings.enabledFeatures = ['reception', 'picking', 'dispatch']` y memberships según roles.
 
 ## Capturas
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,13 +12,11 @@ RUN npm ci
 RUN npx prisma generate
 
 # --- build ---
-FROM deps AS build
+FROM node:18-bullseye-slim AS build
 WORKDIR /usr/src/app
+COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY . .
-# Build del server (usando esbuild como dejaste)
 RUN npm run build
-# Transpila el seed TS a JS para runtime (evita ts-node en producción)
-RUN npx esbuild prisma/seed.ts --platform=node --bundle --format=cjs --outfile=dist/seed.cjs
 
 # --- runner ---
 FROM node:18-bullseye-slim AS runner

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,7 +8,7 @@
       "name": "auditoria-api",
       "version": "2.0.0",
       "dependencies": {
-        "@prisma/client": "^5.10.2",
+        "@prisma/client": "5.22.0",
         "archiver": "^6.0.1",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
@@ -46,11 +46,12 @@
         "jest": "^29.7.0",
         "pino-pretty": "^10.3.1",
         "prettier": "^3.1.1",
-        "prisma": "^5.10.2",
+        "prisma": "5.22.0",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
+        "tsx": "^4.19.0",
         "typescript": "^5.3.3"
       }
     },
@@ -5464,6 +5465,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
@@ -8909,6 +8923,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -10159,6 +10183,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/api/package.json
+++ b/api/package.json
@@ -10,13 +10,14 @@
     "prisma": "prisma",
     "migrate": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev",
-    "seed": "node dist/seed.cjs",
+    "seed": "tsx prisma/seed.ts",
+    "generate": "prisma generate",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "test": "jest --coverage",
     "test:e2e": "jest --config jest.e2e.config.ts"
   },
   "dependencies": {
-    "@prisma/client": "^5.10.2",
+    "@prisma/client": "5.22.0",
     "archiver": "^6.0.1",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
@@ -54,7 +55,8 @@
     "jest": "^29.7.0",
     "pino-pretty": "^10.3.1",
     "prettier": "^3.1.1",
-    "prisma": "^5.10.2",
+    "prisma": "5.22.0",
+    "tsx": "^4.19.0",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
@@ -62,6 +64,6 @@
     "typescript": "^5.3.3"
   },
   "prisma": {
-    "seed": "node dist/seed.cjs"
+    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,217 +1,59 @@
-import 'dotenv/config';
-import { prisma } from '../src/core/config/db.js';
-import { hashPassword } from '../src/core/utils/password.js';
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function upsertUser(email: string, name: string, role: string, password: string) {
+  const passwordHash = await bcrypt.hash(password, 10);
+  return prisma.user.upsert({
+    where: { email },
+    update: { name, role, passwordHash },
+    create: { email, name, role, passwordHash },
+  });
+}
 
 async function main() {
-  await prisma.auditLog.deleteMany();
-  await prisma.membership.deleteMany();
-  await prisma.file.deleteMany();
-  await prisma.kPI.deleteMany();
-  await prisma.decisionLog.deleteMany();
-  await prisma.pOCItem.deleteMany();
-  await prisma.finding.deleteMany();
-  await prisma.risk.deleteMany();
-  await prisma.reception.deleteMany();
-  await prisma.costLicensing.deleteMany();
-  await prisma.performance.deleteMany();
-  await prisma.securityPosture.deleteMany();
-  await prisma.dataModelQuality.deleteMany();
-  await prisma.integration.deleteMany();
-  await prisma.processCoverage.deleteMany();
-  await prisma.systemInventory.deleteMany();
-  await prisma.processAsset.deleteMany();
-  await prisma.interview.deleteMany();
-  await prisma.surveyAnswer.deleteMany();
-  await prisma.surveyResponse.deleteMany();
-  await prisma.surveyQuestion.deleteMany();
-  await prisma.survey.deleteMany();
-  await prisma.dataRequestItem.deleteMany();
-  await prisma.project.deleteMany();
-  await prisma.company.deleteMany();
-  await prisma.user.deleteMany();
-
-  const adminPassword = await hashPassword('admin123');
-  const consultantPassword = await hashPassword('consultor123');
-  const clientPassword = await hashPassword('cliente123');
-
-  const admin = await prisma.user.create({
-    data: { name: 'Admin', email: 'admin@nustrial.com', role: 'admin', passwordHash: adminPassword }
-  });
-  const consultant = await prisma.user.create({
-    data: { name: 'Consultor Demo', email: 'consultor@nustrial.com', role: 'consultor', passwordHash: consultantPassword }
-  });
-  const client = await prisma.user.create({
-    data: { name: 'Cliente Demo', email: 'cliente@nustrial.com', role: 'cliente', passwordHash: clientPassword }
+  // Empresas
+  const nutrial = await prisma.company.upsert({
+    where: { name: 'Nutrial' },
+    update: { taxId: '76.543.210-9' },
+    create: { name: 'Nutrial', taxId: '76.543.210-9' },
   });
 
-  const nutrial = await prisma.company.create({ data: { name: 'Nutrial', taxId: '76.543.210-9' } });
-  const demoCorp = await prisma.company.create({ data: { name: 'DemoCorp', taxId: '12.345.678-5' } });
+  const democorp = await prisma.company.upsert({
+    where: { name: 'DemoCorp' },
+    update: {},
+    create: { name: 'DemoCorp', taxId: '76.000.000-0' },
+  });
 
-  const project = await prisma.project.create({
-    data: {
+  // Usuarios
+  const admin = await upsertUser('admin@demo.com', 'Admin', 'admin', 'Cambiar123!');
+  const consultor = await upsertUser('consultor@demo.com', 'Consultor', 'consultor', 'Cambiar123!');
+  const cliente = await upsertUser('cliente@demo.com', 'Cliente', 'cliente', 'Cambiar123!');
+
+  // Proyecto demo con features
+  await prisma.project.upsert({
+    where: { name: 'Nutrial – Auditoría 2025' },
+    update: {},
+    create: {
       name: 'Nutrial – Auditoría 2025',
-      status: 'En progreso',
+      status: 'active',
       companyId: nutrial.id,
-      ownerId: consultant.id,
-      startDate: new Date(),
-      settings: { enabledFeatures: ['reception', 'picking', 'dispatch'] }
-    }
-  });
-
-  const simplifiedProject = await prisma.project.create({
-    data: {
-      name: 'Nutrial – Diagnóstico Express',
-      status: 'Planificado',
-      companyId: nutrial.id,
-      ownerId: consultant.id,
-      startDate: new Date(),
-      settings: { enabledFeatures: [] }
-    }
-  });
-
-  const demoProject = await prisma.project.create({
-    data: {
-      name: 'DemoCorp – Levantamiento Inicial',
-      status: 'Planificado',
-      companyId: demoCorp.id,
-      ownerId: admin.id,
-      startDate: new Date(),
-      settings: { enabledFeatures: ['dispatch'] }
-    }
-  });
-
-  await prisma.membership.createMany({
-    data: [
-      { userId: admin.id, projectId: project.id, role: 'Admin' },
-      { userId: consultant.id, projectId: project.id, role: 'ConsultorLider' },
-      { userId: client.id, projectId: project.id, role: 'Invitado' },
-      { userId: admin.id, projectId: simplifiedProject.id, role: 'Admin' },
-      { userId: consultant.id, projectId: simplifiedProject.id, role: 'ConsultorLider' },
-      { userId: client.id, projectId: simplifiedProject.id, role: 'Invitado' },
-      { userId: admin.id, projectId: demoProject.id, role: 'Admin' }
-    ]
-  });
-
-  await prisma.dataRequestItem.createMany({
-    data: Array.from({ length: 10 }).map((_, index) => ({
-      projectId: project.id,
-      category: index % 2 === 0 ? 'Finanzas' : 'Operaciones',
-      title: `Solicitud ${index + 1}`,
-      description: 'Detalle requerido',
-      status: index % 3 === 0 ? 'Received' : 'Pending',
-      ownerName: 'Sponsor PM',
-      required: true
-    }))
-  });
-
-  const survey = await prisma.survey.create({
-    data: {
-      projectId: project.id,
-      title: 'Encuesta de Madurez',
-      description: 'Evaluación de percepción',
-      questions: {
-        create: Array.from({ length: 10 }).map((_, index) => ({
-          type: index % 2 === 0 ? 'Likert' : 'Open',
-          text: `Pregunta ${index + 1}`,
-          scaleMin: 1,
-          scaleMax: 5
-        }))
-      }
+      ownerId: consultor.id,
+      settings: { enabledFeatures: ['reception', 'picking', 'dispatch'] },
+      memberships: {
+        create: [
+          { userId: consultor.id, role: 'owner' },
+          { userId: admin.id, role: 'editor' },
+          { userId: cliente.id, role: 'viewer' },
+        ],
+      },
     },
-    include: { questions: true }
   });
 
-  await prisma.surveyResponse.create({
-    data: {
-      surveyId: survey.id,
-      respondent: 'Sponsor',
-      answers: {
-        create: survey.questions.map((question) => ({
-          questionId: question.id,
-          valueNumber: question.type === 'Likert' ? 4 : null,
-          valueText: question.type === 'Open' ? 'Respuesta' : null
-        }))
-      }
-    }
-  });
-
-  await prisma.interview.createMany({
-    data: [
-      { projectId: project.id, personName: 'Operaciones', role: 'Jefe', area: 'Logística' },
-      { projectId: project.id, personName: 'TI', role: 'Líder', area: 'Sistemas' },
-      { projectId: project.id, personName: 'Finanzas', role: 'Analista', area: 'Finanzas' }
-    ]
-  });
-
-  await prisma.systemInventory.createMany({
-    data: Array.from({ length: 5 }).map((_, index) => ({
-      projectId: project.id,
-      systemName: `Sistema ${index + 1}`,
-      type: 'ERP',
-      ownerArea: 'TI',
-      usersActive: 50 + index * 10,
-      criticality: 'Alta'
-    }))
-  });
-
-  await prisma.risk.createMany({
-    data: Array.from({ length: 8 }).map((_, index) => ({
-      projectId: project.id,
-      category: 'Operacional',
-      description: `Riesgo ${index + 1}`,
-      probability: 3,
-      impact: index % 4 + 1,
-      severity: 3 * (index % 4 + 1),
-      rag: index % 3 === 0 ? 'Rojo' : 'Ámbar'
-    }))
-  });
-
-  await prisma.finding.createMany({
-    data: Array.from({ length: 12 }).map((_, index) => ({
-      projectId: project.id,
-      title: `Hallazgo ${index + 1}`,
-      impact: 'Alto',
-      recommendation: 'Implementar mejora',
-      quickWin: index % 2 === 0,
-      effortDays: 5,
-      responsibleR: 'ConsultorLider',
-      accountableA: 'Sponsor',
-      status: index % 3 === 0 ? 'En progreso' : 'Open'
-    }))
-  });
-
-  await prisma.reception.createMany({
-    data: Array.from({ length: 5 }).map((_, index) => ({
-      projectId: project.id,
-      date: new Date(),
-      truckPlate: `ABC-${index}23`,
-      carrier: 'Logística SA',
-      tArriveGate: new Date(Date.now() - 60 * 60 * 1000),
-      tUnloadStart: new Date(Date.now() - 45 * 60 * 1000),
-      tUnloadEnd: new Date(Date.now() - 20 * 60 * 1000),
-      tExit: new Date(),
-      docsOk: true
-    }))
-  });
-
-  await prisma.kPI.createMany({
-    data: Array.from({ length: 6 }).map((_, index) => ({
-      projectId: project.id,
-      name: `KPI ${index + 1}`,
-      value: 70 + index * 2,
-      unit: '%',
-      date: new Date(Date.now() - index * 7 * 24 * 60 * 60 * 1000)
-    }))
-  });
-
-  console.info('Seed completado');
+  console.log('Seed ok:', { nutrial: nutrial.name, democorp: democorp.name, admin: admin.email });
 }
 
 main()
-  .catch((e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+  .then(async () => { await prisma.$disconnect(); })
+  .catch(async (e) => { console.error(e); await prisma.$disconnect(); process.exit(1); });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - postgres-data:/var/lib/postgresql/data
   api:
     build: ./api
-    command: sh -lc "npx prisma migrate deploy && node dist/server.cjs"
+    command: npm run start
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/auditoria
       JWT_SECRET: super-secret

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -4,8 +4,8 @@ import api from "../lib/api";
 import { useNavigate } from "react-router-dom";
 
 export default function Login() {
-  const [email, setEmail] = useState("admin@nustrial.com");
-  const [password, setPassword] = useState("admin123");
+  const [email, setEmail] = useState("admin@demo.com");
+  const [password, setPassword] = useState("Cambiar123!");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const nav = useNavigate();


### PR DESCRIPTION
## Summary
- replace the Prisma seed with a standalone script that only depends on @prisma/client and bcryptjs
- switch npm scripts to execute the seed through tsx and upgrade Prisma to 5.22.0
- adjust Docker build order and docker-compose workflow while updating documentation and login defaults

## Testing
- npm run generate

------
https://chatgpt.com/codex/tasks/task_e_68d7ee6a4c108331bdad4e26774089a8