### PR TITLE
Update seed workflow and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,23 @@ Suite full-stack para gestionar auditorías multi-proyecto con módulos especial
 ## Configuración local
 
 ```bash
+docker compose up -d --build
+docker compose exec api npm run migrate:deploy
+docker compose exec api npm run seed
+```
+
+Una vez que la base de datos está lista, puedes iniciar los servicios de desarrollo individuales si prefieres trabajar fuera de Docker:
+
+```bash
+# API
 cd api
 cp .env.example .env
 npm install
-npx prisma migrate dev
-npm run seed
 npm run dev
-```
 
-En otra terminal:
-
-```bash
-cd web
+# Web
+cd ../web
+cp .env.example .env
 npm install
 npm run dev
 ```
@@ -84,9 +89,9 @@ docker compose up -d --build
 
 Usuarios por defecto:
 
-- `admin@demo.com` / `Cambiar123!`
-- `consultor@demo.com` / `Cambiar123!`
-- `cliente@demo.com` / `Cambiar123!`
+admin@demo.com / Cambiar123!
+consultor@demo.com / Cambiar123!
+cliente@demo.com / Cambiar123!
 
 ## Variables de entorno
 

--- a/api/package.json
+++ b/api/package.json
@@ -8,7 +8,7 @@
     "build": "node -e \"require('esbuild').build({entryPoints:['src/server.ts'], platform:'node', format:'cjs', bundle:true, outfile:'dist/server.cjs', sourcemap:true})\"",
     "start": "node dist/server.cjs",
     "prisma": "prisma",
-    "migrate": "prisma migrate deploy",
+    "migrate:deploy": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev",
     "seed": "tsx prisma/seed.ts",
     "generate": "prisma generate",

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,3 +1,4 @@
+// api/prisma/seed.ts
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 
@@ -12,19 +13,21 @@ async function upsertUser(email: string, name: string, role: string, password: s
   });
 }
 
+async function upsertCompanyByName(name: string, taxId?: string) {
+  const existing = await prisma.company.findFirst({ where: { name } });
+  if (existing) {
+    return prisma.company.update({
+      where: { id: existing.id },
+      data: { taxId },
+    });
+  }
+  return prisma.company.create({ data: { name, taxId } });
+}
+
 async function main() {
   // Empresas
-  const nutrial = await prisma.company.upsert({
-    where: { name: 'Nutrial' },
-    update: { taxId: '76.543.210-9' },
-    create: { name: 'Nutrial', taxId: '76.543.210-9' },
-  });
-
-  const democorp = await prisma.company.upsert({
-    where: { name: 'DemoCorp' },
-    update: {},
-    create: { name: 'DemoCorp', taxId: '76.000.000-0' },
-  });
+  const nutrial = await upsertCompanyByName('Nutrial', '76.543.210-9');
+  const democorp = await upsertCompanyByName('DemoCorp', '76.000.000-0');
 
   // Usuarios
   const admin = await upsertUser('admin@demo.com', 'Admin', 'admin', 'Cambiar123!');
@@ -51,7 +54,10 @@ async function main() {
     },
   });
 
-  console.log('Seed ok:', { nutrial: nutrial.name, democorp: democorp.name, admin: admin.email });
+  console.log('Seed OK', {
+    companies: [nutrial.name, democorp.name],
+    users: ['admin@demo.com', 'consultor@demo.com', 'cliente@demo.com']
+  });
 }
 
 main()


### PR DESCRIPTION
## Summary
- add a migrate:deploy script and keep seeding via tsx in the API package
- replace the Prisma seed with a standalone implementation that avoids company upserts by name
- document the new docker-based local setup and default seed users in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f1e7b5d08331a16e7588a688b4d5