### PR TITLE
Add composite project uniqueness and update seed logic

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -49,6 +49,9 @@ model Project {
   auditLogs    AuditLog[]
   createdAt    DateTime           @default(now())
   updatedAt    DateTime           @updatedAt
+
+  @@unique([companyId, name], name: "Project_companyId_name_key")
+  @@index([companyId])
 }
 
 model User {

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -8,26 +8,23 @@ async function upsertUser(email: string, name: string, role: string, password: s
   const passwordHash = await bcrypt.hash(password, 10);
   return prisma.user.upsert({
     where: { email },
-    update: { name, role, passwordHash },
+    update: {},
     create: { email, name, role, passwordHash },
   });
 }
 
-async function upsertCompanyByName(name: string, taxId?: string) {
+async function findOrCreateCompany(name: string, taxId?: string) {
   const existing = await prisma.company.findFirst({ where: { name } });
   if (existing) {
-    return prisma.company.update({
-      where: { id: existing.id },
-      data: { taxId },
-    });
+    return existing;
   }
   return prisma.company.create({ data: { name, taxId } });
 }
 
 async function main() {
   // Empresas
-  const nutrial = await upsertCompanyByName('Nutrial', '76.543.210-9');
-  const democorp = await upsertCompanyByName('DemoCorp', '76.000.000-0');
+  const nutrial = await findOrCreateCompany('Nutrial', '76.543.210-9');
+  const democorp = await findOrCreateCompany('DemoCorp', '76.000.000-0');
 
   // Usuarios
   const admin = await upsertUser('admin@demo.com', 'Admin', 'admin', 'Cambiar123!');
@@ -36,18 +33,23 @@ async function main() {
 
   // Proyecto demo con features
   await prisma.project.upsert({
-    where: { name: 'Nutrial – Auditoría 2025' },
+    where: {
+      Project_companyId_name_key: {
+        companyId: nutrial.id,
+        name: 'Nutrial – Auditoría 2025',
+      },
+    },
     update: {},
     create: {
+      companyId: nutrial.id,
       name: 'Nutrial – Auditoría 2025',
       status: 'active',
-      companyId: nutrial.id,
-      ownerId: consultor.id,
+      ownerId: admin.id,
       settings: { enabledFeatures: ['reception', 'picking', 'dispatch'] },
       memberships: {
         create: [
-          { userId: consultor.id, role: 'owner' },
-          { userId: admin.id, role: 'editor' },
+          { userId: admin.id, role: 'owner' },
+          { userId: consultor.id, role: 'editor' },
           { userId: cliente.id, role: 'viewer' },
         ],
       },


### PR DESCRIPTION
## Summary
- enforce unique project names per company with a named composite index and supporting company index
- adjust seed users and companies to rely on unique email lookup and idempotent company creation
- update project seeding to use the new composite key and preserve desired memberships

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f91e0b288331aff12b91322e14e8