### PR TITLE
fix: update API build pipeline to use esbuild CLI

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,9 +7,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
-COPY prisma ./prisma
 RUN npm ci
-RUN npx prisma generate
+
+COPY prisma ./prisma
+RUN npm run generate
 
 # --- build ---
 FROM node:18-bullseye-slim AS build
@@ -17,6 +18,7 @@ WORKDIR /usr/src/app
 COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY . .
 RUN npm run build
+RUN npm prune --production
 
 # --- runner ---
 FROM node:18-bullseye-slim AS runner
@@ -25,8 +27,8 @@ ENV NODE_ENV=production
 # Solo lo necesario para correr
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
-COPY --from=build /usr/src/app/prisma ./prisma
-COPY --from=build /usr/src/app/package*.json ./
+COPY prisma ./prisma
+COPY package*.json ./
 EXPOSE 4000
 CMD ["node", "dist/server.cjs"]
 

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
-    "build": "node -e \"require('esbuild').build({entryPoints:['src/server.ts'], platform:'node', format:'cjs', bundle:true, outfile:'dist/server.cjs', sourcemap:true})\"",
+    "build": "esbuild src/server.ts --platform=node --bundle --format=cjs --outfile=dist/server.cjs --sourcemap",
     "start": "node dist/server.cjs",
     "prisma": "prisma",
     "migrate:deploy": "prisma migrate deploy",


### PR DESCRIPTION
## Summary
- switch the build script to invoke the esbuild CLI directly
- adjust the Dockerfile to perform the compilation during the build stage and prune dev dependencies before publishing
- ensure the runtime image only contains the compiled output and production modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8368794b88331bfb0dc023319dc89