### PR TITLE
Add admin shortcuts and refreshable company list for projects

### DIFF
--- a/web/src/pages/AdminDashboard.tsx
+++ b/web/src/pages/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import CompanyManager from '../features/admin/CompanyManager';
@@ -22,6 +22,7 @@ export default function AdminDashboard() {
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [lastProjectId, setLastProjectId] = useState<string | null>(null);
 
   const refreshSummary = useCallback(async () => {
     setLoading(true);
@@ -52,6 +53,17 @@ export default function AdminDashboard() {
     }
   }, [role, refreshSummary]);
 
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setLastProjectId(localStorage.getItem('lastProjectId'));
+    }
+  }, []);
+
+  const quickActionBase = useMemo(
+    () => (lastProjectId ? `/projects/${lastProjectId}` : '/projects'),
+    [lastProjectId],
+  );
+
   if (role !== 'admin') {
     return (
       <div className="mx-auto mt-20 max-w-xl space-y-4 rounded-lg border border-slate-200 bg-white p-6 text-center shadow">
@@ -74,14 +86,22 @@ export default function AdminDashboard() {
 
   return (
     <div className="space-y-8 p-6">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-bold text-slate-900">
-          Panel administrativo
-        </h1>
-        <p className="text-sm text-slate-600">
-          Gestiona compañías, usuarios y obtén visibilidad rápida del estado de
-          la plataforma.
-        </p>
+      <header className="space-y-2 sm:flex sm:items-start sm:justify-between sm:space-y-0">
+        <div>
+          <h1 className="text-3xl font-bold text-slate-900">
+            Panel administrativo
+          </h1>
+          <p className="text-sm text-slate-600">
+            Gestiona compañías, usuarios y obtén visibilidad rápida del estado
+            de la plataforma.
+          </p>
+        </div>
+        <Link
+          to="/projects"
+          className="inline-flex items-center gap-2 rounded border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+        >
+          Volver al sistema
+        </Link>
       </header>
 
       {error && (
@@ -110,6 +130,68 @@ export default function AdminDashboard() {
           </p>
           {loading && <p className="text-xs text-slate-500">Actualizando…</p>}
         </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <article className="flex h-full flex-col justify-between rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold text-slate-800">
+              Exportación ejecutiva
+            </h2>
+            <p className="text-sm text-slate-600">
+              Descarga reportes consolidados en Excel y comparte avances con los
+              stakeholders.
+            </p>
+          </div>
+          <Link
+            to={`${quickActionBase}${quickActionBase.endsWith('/projects') ? '' : '/export'}`}
+            className="mt-4 inline-flex items-center justify-center rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white transition hover:bg-slate-800"
+          >
+            Ir a exportación
+          </Link>
+        </article>
+        <article className="flex h-full flex-col justify-between rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold text-slate-800">
+              Configuración del proyecto
+            </h2>
+            <p className="text-sm text-slate-600">
+              Ajusta datos base, miembros y el alcance del proyecto de
+              auditoría.
+            </p>
+          </div>
+          <Link
+            to={quickActionBase}
+            className="mt-4 inline-flex items-center justify-center rounded bg-slate-100 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-200"
+          >
+            Abrir proyectos
+          </Link>
+        </article>
+        <article className="flex h-full flex-col justify-between rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold text-slate-800">
+              Seguridad y sistemas
+            </h2>
+            <p className="text-sm text-slate-600">
+              Accede rápidamente a los tableros de seguridad y sistemas para
+              revisar hallazgos técnicos.
+            </p>
+          </div>
+          <div className="mt-4 flex gap-2">
+            <Link
+              to={`${quickActionBase}${quickActionBase.endsWith('/projects') ? '' : '/security'}`}
+              className="flex-1 rounded bg-slate-100 px-3 py-2 text-center text-sm font-medium text-slate-700 transition hover:bg-slate-200"
+            >
+              Seguridad
+            </Link>
+            <Link
+              to={`${quickActionBase}${quickActionBase.endsWith('/projects') ? '' : '/systems'}`}
+              className="flex-1 rounded bg-slate-100 px-3 py-2 text-center text-sm font-medium text-slate-700 transition hover:bg-slate-200"
+            >
+              Sistemas
+            </Link>
+          </div>
+        </article>
       </section>
 
       <div className="grid gap-8 lg:grid-cols-2">


### PR DESCRIPTION
## Summary
- add a return shortcut and quick links to the admin dashboard for export, configuración, and security sections
- fetch companies directly from the API when opening the project creation modal so recently created companies are available
- show loading and error feedback in the company selector and prevent submissions until data is ready

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d8577e62448331ae2bd780b34d7e2a