### PR TITLE
Add project summary dashboards and planning tools

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Project {
   memberships  Membership[]
   files        File[]
   dataItems    DataRequestItem[]
+  tasks        ProjectTask[]
   surveys      Survey[]
   interviews   Interview[]
   processes    ProcessAsset[]
@@ -111,6 +112,14 @@ model DataRequestItem {
   project     Project   @relation(fields: [projectId], references: [id])
   /// DUEÑO DE LA FK + NOMBRE DE RELACIÓN
   file        File?     @relation(name: "FileToDataRequestItems", fields: [fileId], references: [id])
+}
+
+model DataRequestCategory {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model Survey {
@@ -296,6 +305,28 @@ model CostLicensing {
   supportUSD    Float?
   otherUSD      Float?
   project       Project @relation(fields: [projectId], references: [id])
+}
+
+model ProjectTask {
+  id          String        @id @default(cuid())
+  projectId   String
+  parentId    String?
+  name        String
+  description String?
+  owner       String?
+  status      String        @default("Planificado")
+  progress    Int?
+  startDate   DateTime
+  endDate     DateTime
+  sortOrder   Int?
+  project     Project       @relation(fields: [projectId], references: [id])
+  parent      ProjectTask?  @relation("ProjectTaskChildren", fields: [parentId], references: [id])
+  children    ProjectTask[] @relation("ProjectTaskChildren")
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  @@index([projectId])
+  @@index([parentId])
 }
 
 model Risk {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -4,6 +4,7 @@ import { authRouter } from './modules/auth/auth.router.js';
 import { projectRouter } from './modules/projects/project.router.js';
 import { companyRouter } from './modules/companies/company.router.js';
 import { dataRequestRouter } from './modules/dataRequest/data-request.router.js';
+import { dataRequestCategoryRouter } from './modules/dataRequestCategories/data-request-category.router.js';
 import { surveyRouter } from './modules/surveys/survey.router.js';
 import { interviewRouter } from './modules/interviews/interview.router.js';
 import { processRouter } from './modules/processes/process.router.js';
@@ -16,6 +17,7 @@ import { userRouter } from './modules/users/user.router.js';
 import { exportRouter } from './modules/export/export.router.js';
 import { auditRouter } from './modules/audit/audit.router.js';
 import { fileRouter } from './modules/files/file.router.js';
+import { projectPlanRouter } from './modules/projectPlan/project-plan.router.js';
 
 const appRouter = Router();
 
@@ -23,6 +25,7 @@ appRouter.use('/auth', authRouter);
 appRouter.use('/projects', projectRouter);
 appRouter.use('/companies', companyRouter);
 appRouter.use('/data-request', dataRequestRouter);
+appRouter.use('/data-request-categories', dataRequestCategoryRouter);
 appRouter.use('/surveys', surveyRouter);
 appRouter.use('/interviews', interviewRouter);
 appRouter.use('/process-assets', processRouter);
@@ -35,5 +38,6 @@ appRouter.use('/users', userRouter);
 appRouter.use('/export', exportRouter);
 appRouter.use('/audit', auditRouter);
 appRouter.use('/files', fileRouter);
+appRouter.use('/project-plan', projectPlanRouter);
 
 export { appRouter };

--- a/api/src/modules/dataRequestCategories/data-request-category.router.ts
+++ b/api/src/modules/dataRequestCategories/data-request-category.router.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+
+import { authenticate, requireRole } from '../../core/middleware/auth.js';
+import { dataRequestCategoryService } from './data-request-category.service.js';
+
+const dataRequestCategoryRouter = Router();
+
+dataRequestCategoryRouter.use(authenticate);
+
+dataRequestCategoryRouter.get('/', async (_req, res) => {
+  const categories = await dataRequestCategoryService.list();
+  res.json(categories);
+});
+
+dataRequestCategoryRouter.post('/', requireRole('admin'), async (req, res) => {
+  const category = await dataRequestCategoryService.create(req.body, req.user!.id);
+  res.status(201).json(category);
+});
+
+dataRequestCategoryRouter.put(
+  '/:categoryId',
+  requireRole('admin'),
+  async (req, res) => {
+    const category = await dataRequestCategoryService.update(
+      req.params.categoryId,
+      req.body,
+      req.user!.id
+    );
+    res.json(category);
+  }
+);
+
+dataRequestCategoryRouter.delete(
+  '/:categoryId',
+  requireRole('admin'),
+  async (req, res) => {
+    await dataRequestCategoryService.remove(req.params.categoryId, req.user!.id);
+    res.status(204).send();
+  }
+);
+
+export { dataRequestCategoryRouter };

--- a/api/src/modules/dataRequestCategories/data-request-category.service.ts
+++ b/api/src/modules/dataRequestCategories/data-request-category.service.ts
@@ -1,0 +1,65 @@
+import { prisma } from '../../core/config/db.js';
+import { HttpError } from '../../core/errors/http-error.js';
+import { auditService } from '../audit/audit.service.js';
+
+export const dataRequestCategoryService = {
+  async list() {
+    return prisma.dataRequestCategory.findMany({ orderBy: { name: 'asc' } });
+  },
+
+  async create(payload: { name: string; description?: string }, userId: string) {
+    const category = await prisma.dataRequestCategory.create({ data: payload });
+    await auditService.record(
+      'DataRequestCategory',
+      category.id,
+      'CREATE',
+      userId,
+      null,
+      null,
+      category
+    );
+    return category;
+  },
+
+  async update(
+    id: string,
+    payload: { name?: string; description?: string },
+    userId: string
+  ) {
+    const before = await prisma.dataRequestCategory.findUnique({ where: { id } });
+    if (!before) {
+      throw new HttpError(404, 'Categoría no encontrada');
+    }
+    const category = await prisma.dataRequestCategory.update({
+      where: { id },
+      data: payload,
+    });
+    await auditService.record(
+      'DataRequestCategory',
+      id,
+      'UPDATE',
+      userId,
+      null,
+      before,
+      category
+    );
+    return category;
+  },
+
+  async remove(id: string, userId: string) {
+    const before = await prisma.dataRequestCategory.findUnique({ where: { id } });
+    if (!before) {
+      throw new HttpError(404, 'Categoría no encontrada');
+    }
+    await prisma.dataRequestCategory.delete({ where: { id } });
+    await auditService.record(
+      'DataRequestCategory',
+      id,
+      'DELETE',
+      userId,
+      null,
+      before,
+      null
+    );
+  },
+};

--- a/api/src/modules/projectPlan/project-plan.router.ts
+++ b/api/src/modules/projectPlan/project-plan.router.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+
+import { authenticate, requireProjectRole } from '../../core/middleware/auth.js';
+import { projectPlanService } from './project-plan.service.js';
+
+const projectPlanRouter = Router();
+
+projectPlanRouter.use(authenticate);
+
+const readRoles = ['ConsultorLider', 'Auditor', 'SponsorPM', 'Invitado'];
+const writeRoles = ['ConsultorLider', 'Auditor'];
+
+projectPlanRouter.get(
+  '/:projectId',
+  requireProjectRole(readRoles),
+  async (req, res) => {
+    const tasks = await projectPlanService.list(req.params.projectId);
+    res.json(tasks);
+  }
+);
+
+projectPlanRouter.post(
+  '/:projectId',
+  requireProjectRole(writeRoles),
+  async (req, res) => {
+    const task = await projectPlanService.create(
+      req.params.projectId,
+      req.body,
+      req.user!.id
+    );
+    res.status(201).json(task);
+  }
+);
+
+projectPlanRouter.put(
+  '/:projectId/:taskId',
+  requireProjectRole(writeRoles),
+  async (req, res) => {
+    const task = await projectPlanService.update(
+      req.params.taskId,
+      req.body,
+      req.user!.id
+    );
+    res.json(task);
+  }
+);
+
+projectPlanRouter.delete(
+  '/:projectId/:taskId',
+  requireProjectRole(['ConsultorLider']),
+  async (req, res) => {
+    await projectPlanService.remove(req.params.taskId, req.user!.id);
+    res.status(204).send();
+  }
+);
+
+export { projectPlanRouter };

--- a/api/src/modules/projectPlan/project-plan.service.ts
+++ b/api/src/modules/projectPlan/project-plan.service.ts
@@ -1,0 +1,76 @@
+import { prisma } from '../../core/config/db.js';
+import { HttpError } from '../../core/errors/http-error.js';
+import { auditService } from '../audit/audit.service.js';
+
+export const projectPlanService = {
+  async list(projectId: string) {
+    return prisma.projectTask.findMany({
+      where: { projectId },
+      orderBy: [
+        { sortOrder: 'asc' },
+        { startDate: 'asc' },
+        { createdAt: 'asc' },
+      ],
+    });
+  },
+
+  async create(projectId: string, payload: any, userId: string) {
+    const task = await prisma.projectTask.create({
+      data: { ...payload, projectId },
+    });
+    await auditService.record(
+      'ProjectTask',
+      task.id,
+      'CREATE',
+      userId,
+      projectId,
+      null,
+      task
+    );
+    return task;
+  },
+
+  async update(taskId: string, payload: any, userId: string) {
+    const before = await prisma.projectTask.findUnique({ where: { id: taskId } });
+    if (!before) {
+      throw new HttpError(404, 'Tarea no encontrada');
+    }
+    const task = await prisma.projectTask.update({
+      where: { id: taskId },
+      data: payload,
+    });
+    await auditService.record(
+      'ProjectTask',
+      taskId,
+      'UPDATE',
+      userId,
+      before.projectId,
+      before,
+      task
+    );
+    return task;
+  },
+
+  async remove(taskId: string, userId: string) {
+    const before = await prisma.projectTask.findUnique({ where: { id: taskId } });
+    if (!before) {
+      throw new HttpError(404, 'Tarea no encontrada');
+    }
+
+    await prisma.projectTask.updateMany({
+      where: { parentId: taskId },
+      data: { parentId: null },
+    });
+
+    await prisma.projectTask.delete({ where: { id: taskId } });
+    await auditService.record(
+      'ProjectTask',
+      taskId,
+      'DELETE',
+      userId,
+      before.projectId,
+      before,
+      null
+    );
+  },
+};

--- a/api/src/modules/projects/project.router.ts
+++ b/api/src/modules/projects/project.router.ts
@@ -21,6 +21,14 @@ projectRouter.get('/:projectId/features', async (req, res) => {
   res.json(result);
 });
 
+projectRouter.get('/:projectId/summary', async (req, res) => {
+  const summary = await projectService.summary(req.params.projectId, {
+    id: req.user!.id,
+    role: req.user!.role
+  });
+  res.json(summary);
+});
+
 projectRouter.get('/:projectId', async (req, res) => {
   const project = await projectService.getById(req.params.projectId, {
     id: req.user!.id,

--- a/api/src/modules/projects/project.service.ts
+++ b/api/src/modules/projects/project.service.ts
@@ -115,5 +115,204 @@ export const projectService = {
     const rawFeatures = Array.isArray(raw?.enabledFeatures) ? raw?.enabledFeatures ?? [] : [];
     const enabled = rawFeatures.filter((feature): feature is string => typeof feature === 'string');
     return { enabled };
+  },
+
+  async summary(id: string, user: { id: string; role: string }) {
+    await enforceProjectAccess(user, id);
+    const project = await prisma.project.findUnique({
+      where: { id },
+      include: { company: true },
+    });
+    if (!project) {
+      throw new HttpError(404, 'Proyecto no encontrado');
+    }
+
+    const enabledFeatures = extractEnabledFeatures(project.settings);
+
+    const [
+      dataItems,
+      surveys,
+      surveyResponses,
+      interviewsCount,
+      processAssetsCount,
+      inventoryCount,
+      coverages,
+      integrationsCount,
+      dataQualityCount,
+      securityEntries,
+      performanceCount,
+      costEntries,
+      risks,
+      findings,
+      pocItems,
+      decisionsCount,
+      kpis,
+      tasks,
+    ] = await Promise.all([
+      prisma.dataRequestItem.findMany({ where: { projectId: id } }),
+      prisma.survey.findMany({ where: { projectId: id }, include: { questions: true } }),
+      prisma.surveyResponse.count({ where: { survey: { projectId: id } } }),
+      prisma.interview.count({ where: { projectId: id } }),
+      prisma.processAsset.count({ where: { projectId: id } }),
+      prisma.systemInventory.count({ where: { projectId: id } }),
+      prisma.processCoverage.findMany({ where: { projectId: id } }),
+      prisma.integration.count({ where: { projectId: id } }),
+      prisma.dataModelQuality.count({ where: { projectId: id } }),
+      prisma.securityPosture.findMany({ where: { projectId: id } }),
+      prisma.performance.count({ where: { projectId: id } }),
+      prisma.costLicensing.findMany({ where: { projectId: id } }),
+      prisma.risk.findMany({ where: { projectId: id } }),
+      prisma.finding.findMany({ where: { projectId: id } }),
+      prisma.pOCItem.findMany({ where: { projectId: id } }),
+      prisma.decisionLog.count({ where: { projectId: id } }),
+      prisma.kPI.findMany({ where: { projectId: id }, orderBy: { date: 'desc' } }),
+      prisma.projectTask.findMany({ where: { projectId: id } }),
+    ]);
+
+    const now = new Date();
+    const pendingDataItems = dataItems.filter((item) =>
+      ['Pending', 'En progreso', 'Pendiente'].includes(item.status)
+    );
+    const overdueDataItems = dataItems.filter(
+      (item) => item.dueDate && new Date(item.dueDate) < now && item.status !== 'Recibido'
+    );
+
+    const coverageAverage = coverages.length
+      ? coverages.reduce((acc, item) => acc + (item.coverage ?? 0), 0) / coverages.length
+      : null;
+    const coverageGaps = coverages.filter((item) => item.hasGap).length;
+
+    const openVulnerabilities = securityEntries.filter(
+      (entry) => (entry.openVulns ?? '').trim().length > 0
+    ).length;
+
+    const totalTco = costEntries.reduce((acc, item) => acc + computeTco(item), 0);
+
+    const criticalRisks = risks.filter((risk) =>
+      risk.severity >= 4 || (risk.rag ?? '').toLowerCase() === 'rojo'
+    ).length;
+
+    const openFindings = findings.filter((finding) => {
+      const status = (finding.status ?? '').toLowerCase();
+      return status !== 'closed' && status !== 'cerrado' && status !== 'implementado';
+    }).length;
+
+    const activePoc = pocItems.filter((item) => {
+      const status = (item.status ?? '').toLowerCase();
+      return status !== 'completado' && status !== 'cerrado';
+    }).length;
+
+    const lateTasks = tasks.filter((task) =>
+      task.endDate < now && !['completado', 'cerrado'].includes((task.status ?? '').toLowerCase())
+    );
+    const upcomingTasks = tasks
+      .filter((task) => task.startDate >= now)
+      .sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
+    const nextTask = upcomingTasks[0] ?? null;
+
+    return {
+      project: {
+        id: project.id,
+        name: project.name,
+        status: project.status,
+        company: project.company,
+        startDate: project.startDate,
+        endDate: project.endDate,
+      },
+      sections: {
+        preKickoff: {
+          total: dataItems.length,
+          pending: pendingDataItems.length,
+          overdue: overdueDataItems.length,
+        },
+        surveys: {
+          total: surveys.length,
+          active: surveys.filter((survey) => survey.isActive).length,
+          questions: surveys.reduce((acc, survey) => acc + survey.questions.length, 0),
+          responses: surveyResponses,
+        },
+        interviews: {
+          total: interviewsCount,
+        },
+        processes: {
+          deliverables: processAssetsCount,
+          featuresEnabled: enabledFeatures.length,
+        },
+        systems: {
+          inventory: inventoryCount,
+          integrations: integrationsCount,
+          coverage: coverages.length,
+          gaps: coverageGaps,
+          averageCoverage: coverageAverage,
+          dataQuality: dataQualityCount,
+        },
+        security: {
+          posture: securityEntries.length,
+          openVulnerabilities,
+          performance: performanceCount,
+          costs: costEntries.length,
+          totalTco,
+        },
+        risks: {
+          total: risks.length,
+          critical: criticalRisks,
+        },
+        findings: {
+          total: findings.length,
+          open: openFindings,
+        },
+        poc: {
+          total: pocItems.length,
+          active: activePoc,
+        },
+        decisions: {
+          total: decisionsCount,
+        },
+        kpis: {
+          total: kpis.length,
+          latest: kpis[0]
+            ? {
+                id: kpis[0].id,
+                name: kpis[0].name,
+                value: kpis[0].value,
+                unit: kpis[0].unit,
+                date: kpis[0].date,
+              }
+            : null,
+        },
+        gantt: {
+          total: tasks.length,
+          late: lateTasks.length,
+          next: nextTask
+            ? {
+                id: nextTask.id,
+                name: nextTask.name,
+                startDate: nextTask.startDate,
+              }
+            : null,
+        },
+      },
+    };
   }
+};
+
+const extractEnabledFeatures = (settings: Prisma.JsonValue | null) => {
+  const raw = settings as { enabledFeatures?: unknown } | null;
+  const rawFeatures = Array.isArray(raw?.enabledFeatures) ? raw?.enabledFeatures ?? [] : [];
+  return rawFeatures.filter((feature): feature is string => typeof feature === 'string');
+};
+
+const computeTco = (cost: {
+  costAnnual?: number | null;
+  implUSD?: number | null;
+  infraUSD?: number | null;
+  supportUSD?: number | null;
+  otherUSD?: number | null;
+}) => {
+  const costAnnual = cost.costAnnual ?? 0;
+  const implUSD = cost.implUSD ?? 0;
+  const infraUSD = cost.infraUSD ?? 0;
+  const supportUSD = cost.supportUSD ?? 0;
+  const otherUSD = cost.otherUSD ?? 0;
+  return costAnnual * 3 + implUSD + infraUSD * 3 + supportUSD * 3 + otherUSD;
 };

--- a/web/src/features/admin/DataRequestCategoryManager.tsx
+++ b/web/src/features/admin/DataRequestCategoryManager.tsx
@@ -1,0 +1,262 @@
+import { FormEvent, useEffect, useState } from 'react';
+
+import api from '../../lib/api';
+import { getErrorMessage } from '../../lib/errors';
+
+interface DataRequestCategory {
+  id: string;
+  name: string;
+  description?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const defaultForm = {
+  name: '',
+  description: '',
+};
+
+interface Props {
+  onChange?: () => void;
+}
+
+export default function DataRequestCategoryManager({ onChange }: Props) {
+  const [categories, setCategories] = useState<DataRequestCategory[]>([]);
+  const [form, setForm] = useState(defaultForm);
+  const [editing, setEditing] = useState<DataRequestCategory | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadCategories = async () => {
+    setLoading(true);
+    try {
+      const response = await api.get<DataRequestCategory[]>(
+        '/data-request-categories'
+      );
+      setCategories(response.data ?? []);
+      setError(null);
+    } catch (error: unknown) {
+      setError(
+        getErrorMessage(error, 'No se pudieron cargar las categorías disponibles')
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadCategories();
+  }, []);
+
+  const resetForm = () => {
+    setForm(defaultForm);
+  };
+
+  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      await api.post('/data-request-categories', {
+        name: form.name,
+        description: form.description || undefined,
+      });
+      resetForm();
+      await loadCategories();
+      onChange?.();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo crear la categoría'));
+    }
+  };
+
+  const handleUpdate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editing) return;
+    try {
+      await api.put(`/data-request-categories/${editing.id}`, {
+        name: editing.name,
+        description: editing.description || undefined,
+      });
+      setEditing(null);
+      await loadCategories();
+      onChange?.();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo actualizar la categoría'));
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await api.delete(`/data-request-categories/${id}`);
+      await loadCategories();
+      onChange?.();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo eliminar la categoría'));
+    }
+  };
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-slate-900">
+          Categorías pre-kickoff
+        </h2>
+        <p className="text-sm text-slate-500">
+          Define el catálogo de categorías disponibles para las solicitudes de
+          datos pre-kickoff.
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </p>
+      )}
+
+      {!editing && (
+        <form
+          onSubmit={handleCreate}
+          className="grid gap-3 rounded-lg border border-slate-200 p-4"
+        >
+          <h3 className="text-base font-medium text-slate-800">
+            Nueva categoría
+          </h3>
+          <label className="flex flex-col text-sm">
+            Nombre
+            <input
+              className="mt-1 rounded border px-3 py-2"
+              value={form.name}
+              onChange={(event) =>
+                setForm((prev) => ({ ...prev, name: event.target.value }))
+              }
+              required
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            Descripción
+            <textarea
+              className="mt-1 rounded border px-3 py-2"
+              value={form.description}
+              onChange={(event) =>
+                setForm((prev) => ({ ...prev, description: event.target.value }))
+              }
+              rows={2}
+            />
+          </label>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              className="rounded bg-slate-100 px-3 py-2 text-sm text-slate-600"
+              onClick={resetForm}
+            >
+              Limpiar
+            </button>
+            <button
+              type="submit"
+              className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+            >
+              Crear categoría
+            </button>
+          </div>
+        </form>
+      )}
+
+      {editing && (
+        <form
+          onSubmit={handleUpdate}
+          className="grid gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+        >
+          <div className="flex items-center justify-between">
+            <h3 className="text-base font-medium text-slate-800">
+              Editar categoría
+            </h3>
+            <button
+              type="button"
+              className="text-sm text-blue-700 underline"
+              onClick={() => setEditing(null)}
+            >
+              Cancelar
+            </button>
+          </div>
+          <label className="flex flex-col text-sm">
+            Nombre
+            <input
+              className="mt-1 rounded border px-3 py-2"
+              value={editing.name}
+              onChange={(event) =>
+                setEditing((prev) =>
+                  prev ? { ...prev, name: event.target.value } : prev
+                )
+              }
+              required
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            Descripción
+            <textarea
+              className="mt-1 rounded border px-3 py-2"
+              value={editing.description ?? ''}
+              onChange={(event) =>
+                setEditing((prev) =>
+                  prev ? { ...prev, description: event.target.value } : prev
+                )
+              }
+              rows={2}
+            />
+          </label>
+          <div className="flex justify-end gap-2">
+            <button
+              type="submit"
+              className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+            >
+              Actualizar
+            </button>
+          </div>
+        </form>
+      )}
+
+      <div className="space-y-2">
+        <h3 className="text-base font-semibold text-slate-800">
+          Catálogo disponible
+        </h3>
+        {loading && (
+          <p className="text-sm text-slate-500">Cargando categorías…</p>
+        )}
+        {!loading && categories.length === 0 && (
+          <p className="text-sm text-slate-500">
+            Aún no hay categorías configuradas.
+          </p>
+        )}
+        <div className="space-y-2">
+          {categories.map((category) => (
+            <div
+              key={category.id}
+              className="flex flex-wrap items-center justify-between gap-2 rounded border border-slate-200 bg-white p-3 shadow-sm"
+            >
+              <div>
+                <p className="text-sm font-medium text-slate-800">
+                  {category.name}
+                </p>
+                {category.description && (
+                  <p className="text-xs text-slate-500">{category.description}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  className="rounded bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                  onClick={() => setEditing(category)}
+                >
+                  Editar
+                </button>
+                <button
+                  className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white"
+                  onClick={() => handleDelete(category.id)}
+                >
+                  Eliminar
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/features/projects/ProjectTabs.tsx
+++ b/web/src/features/projects/ProjectTabs.tsx
@@ -1,6 +1,10 @@
 import { FC } from 'react';
 
 import PreKickoffTab from './tabs/PreKickoffTab';
+import SummaryTab from './tabs/SummaryTab';
+import ProjectPlanTab from './tabs/ProjectPlanTab';
+import SystemsTab from './tabs/SystemsTab';
+import SecurityTab from './tabs/SecurityTab';
 import SurveysTab from './tabs/SurveysTab';
 import InterviewsTab from './tabs/InterviewsTab';
 import ProcessesTab from './tabs/ProcessesTab';
@@ -14,42 +18,19 @@ interface TabComponentProps {
   projectId: string;
 }
 
-const makeSection = (
-  title: string,
-  description: string
-): FC<TabComponentProps> =>
-  function Section({ projectId }) {
-    return (
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold text-slate-900">{title}</h2>
-        <p className="text-sm text-slate-500">{description}</p>
-        <p className="text-xs text-slate-400">Proyecto: {projectId}</p>
-      </div>
-    );
-  };
-
 export const ProjectTabs: {
   value: string;
   label: string;
   component: FC<TabComponentProps>;
 }[] = [
+  { value: 'summary', label: 'Resumen', component: SummaryTab },
   { value: 'prekickoff', label: 'Datos Pre-Kickoff', component: PreKickoffTab },
+  { value: 'plan', label: 'Plan del Proyecto', component: ProjectPlanTab },
   { value: 'surveys', label: 'Encuestas', component: SurveysTab },
   { value: 'interviews', label: 'Entrevistas', component: InterviewsTab },
   { value: 'processes', label: 'Procesos', component: ProcessesTab },
-  {
-    value: 'systems',
-    label: 'Sistemas',
-    component: makeSection(
-      'Sistemas',
-      'Inventario, cobertura, integraciones y data.'
-    ),
-  },
-  {
-    value: 'security',
-    label: 'Seguridad',
-    component: makeSection('Seguridad', 'Postura, performance y costos/TCO.'),
-  },
+  { value: 'systems', label: 'Sistemas', component: SystemsTab },
+  { value: 'security', label: 'Seguridad', component: SecurityTab },
   { value: 'risks', label: 'Riesgos', component: RisksTab },
   { value: 'findings', label: 'Hallazgos', component: FindingsTab },
   { value: 'poc', label: 'POC', component: POCTab },

--- a/web/src/features/projects/tabs/ProjectPlanTab.tsx
+++ b/web/src/features/projects/tabs/ProjectPlanTab.tsx
@@ -1,0 +1,656 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import api from '../../../lib/api';
+import { useAuth } from '../../../hooks/useAuth';
+import { getErrorMessage } from '../../../lib/errors';
+
+interface ProjectTask {
+  id: string;
+  name: string;
+  description?: string | null;
+  owner?: string | null;
+  status: string;
+  progress?: number | null;
+  startDate: string;
+  endDate: string;
+  parentId?: string | null;
+  sortOrder?: number | null;
+}
+
+interface ProjectPlanTabProps {
+  projectId: string;
+}
+
+interface TaskNode extends ProjectTask {
+  children: TaskNode[];
+  depth: number;
+}
+
+const TASK_STATUS = ['Planificado', 'En progreso', 'Completado'];
+
+const STATUS_COLOR: Record<string, string> = {
+  Planificado: 'bg-slate-300',
+  'En progreso': 'bg-blue-500',
+  Completado: 'bg-emerald-500',
+};
+
+const defaultForm = {
+  name: '',
+  owner: '',
+  status: 'Planificado',
+  progress: 0,
+  startDate: '',
+  endDate: '',
+  parentId: '',
+  description: '',
+};
+
+const parseDate = (value: string) => new Date(value);
+
+const buildHierarchy = (tasks: ProjectTask[]): TaskNode[] => {
+  const map = new Map<string, TaskNode>();
+  tasks.forEach((task) => {
+    map.set(task.id, { ...task, children: [], depth: 0 });
+  });
+  const roots: TaskNode[] = [];
+  const attach = (node: TaskNode) => {
+    if (node.parentId && map.has(node.parentId)) {
+      const parent = map.get(node.parentId)!;
+      node.depth = parent.depth + 1;
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  };
+  map.forEach(attach);
+
+  const sortNodes = (nodes: TaskNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.sortOrder !== null && a.sortOrder !== undefined && b.sortOrder !== null && b.sortOrder !== undefined) {
+        return a.sortOrder - b.sortOrder;
+      }
+      return parseDate(a.startDate).getTime() - parseDate(b.startDate).getTime();
+    });
+    nodes.forEach((node) => sortNodes(node.children));
+  };
+
+  sortNodes(roots);
+  return roots;
+};
+
+const flattenHierarchy = (nodes: TaskNode[]): TaskNode[] => {
+  const result: TaskNode[] = [];
+  const visit = (list: TaskNode[]) => {
+    list.forEach((node) => {
+      result.push(node);
+      if (node.children.length > 0) {
+        visit(node.children);
+      }
+    });
+  };
+  visit(nodes);
+  return result;
+};
+
+const getTimelineBounds = (tasks: ProjectTask[]) => {
+  if (!tasks.length) {
+    const today = new Date();
+    return { start: today, end: today };
+  }
+  let min = parseDate(tasks[0].startDate);
+  let max = parseDate(tasks[0].endDate);
+  tasks.forEach((task) => {
+    const start = parseDate(task.startDate);
+    const end = parseDate(task.endDate);
+    if (start < min) min = start;
+    if (end > max) max = end;
+  });
+  return { start: min, end: max };
+};
+
+const formatDate = (value: string) => new Date(value).toLocaleDateString();
+
+export default function ProjectPlanTab({ projectId }: ProjectPlanTabProps) {
+  const { role } = useAuth();
+  const canEdit = useMemo(() => ['admin', 'consultor'].includes(role), [role]);
+  const isAdmin = role === 'admin';
+  const [tasks, setTasks] = useState<ProjectTask[]>([]);
+  const [form, setForm] = useState(defaultForm);
+  const [editing, setEditing] = useState<ProjectTask | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadTasks = useCallback(async () => {
+    if (!projectId) return;
+    setLoading(true);
+    try {
+      const response = await api.get<ProjectTask[]>(`/project-plan/${projectId}`);
+      setTasks(response.data ?? []);
+      setError(null);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo cargar el plan del proyecto'));
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void loadTasks();
+  }, [loadTasks]);
+
+  const resetForm = () => {
+    setForm(defaultForm);
+  };
+
+  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+    try {
+      await api.post(`/project-plan/${projectId}`, {
+        name: form.name,
+        owner: form.owner || undefined,
+        status: form.status,
+        progress: Number(form.progress) || 0,
+        startDate: new Date(form.startDate).toISOString(),
+        endDate: new Date(form.endDate).toISOString(),
+        parentId: form.parentId || undefined,
+        description: form.description || undefined,
+        sortOrder: tasks.length,
+      });
+      resetForm();
+      await loadTasks();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo crear la tarea'));
+    }
+  };
+
+  const handleUpdate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editing) return;
+    try {
+      await api.put(`/project-plan/${projectId}/${editing.id}`, {
+        name: editing.name,
+        owner: editing.owner || undefined,
+        status: editing.status,
+        progress:
+          editing.progress !== null && editing.progress !== undefined
+            ? Number(editing.progress)
+            : 0,
+        startDate: new Date(editing.startDate).toISOString(),
+        endDate: new Date(editing.endDate).toISOString(),
+        parentId: editing.parentId || undefined,
+        description: editing.description || undefined,
+        sortOrder: editing.sortOrder ?? undefined,
+      });
+      setEditing(null);
+      await loadTasks();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo actualizar la tarea'));
+    }
+  };
+
+  const removeTask = async (id: string) => {
+    if (!isAdmin) return;
+    try {
+      await api.delete(`/project-plan/${projectId}/${id}`);
+      await loadTasks();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo eliminar la tarea'));
+    }
+  };
+
+  const hierarchy = useMemo(() => buildHierarchy(tasks), [tasks]);
+  const flatTasks = useMemo(() => flattenHierarchy(hierarchy), [hierarchy]);
+  const timeline = useMemo(() => getTimelineBounds(tasks), [tasks]);
+  const totalDuration = Math.max(
+    1,
+    Math.round(
+      (timeline.end.getTime() - timeline.start.getTime()) / (1000 * 60 * 60 * 24)
+    ) + 1
+  );
+
+  const availableParents = editing
+    ? tasks.filter((task) => task.id !== editing.id)
+    : tasks;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Plan del proyecto</h2>
+        <p className="text-sm text-slate-500">
+          Crea hitos, asigna responsables y visualiza la carta Gantt del proyecto.
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </p>
+      )}
+
+      {canEdit && !editing && (
+        <form
+          onSubmit={handleCreate}
+          className="grid gap-3 rounded-lg border border-slate-200 p-4"
+        >
+          <h3 className="text-lg font-medium text-slate-800">Nueva tarea</h3>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <label className="flex flex-col text-sm">
+              Nombre
+              <input
+                className="mt-1 rounded border px-3 py-2"
+                value={form.name}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, name: event.target.value }))
+                }
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Responsable
+              <input
+                className="mt-1 rounded border px-3 py-2"
+                value={form.owner}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, owner: event.target.value }))
+                }
+                placeholder="Nombre del responsable"
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Estado
+              <select
+                className="mt-1 rounded border px-3 py-2"
+                value={form.status}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, status: event.target.value }))
+                }
+              >
+                {TASK_STATUS.map((status) => (
+                  <option key={status} value={status}>
+                    {status}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col text-sm">
+              Progreso (%)
+              <input
+                type="number"
+                min={0}
+                max={100}
+                className="mt-1 rounded border px-3 py-2"
+                value={form.progress}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, progress: Number(event.target.value) }))
+                }
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Fecha inicio
+              <input
+                type="date"
+                className="mt-1 rounded border px-3 py-2"
+                value={form.startDate}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, startDate: event.target.value }))
+                }
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Fecha término
+              <input
+                type="date"
+                className="mt-1 rounded border px-3 py-2"
+                value={form.endDate}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, endDate: event.target.value }))
+                }
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Tarea padre
+              <select
+                className="mt-1 rounded border px-3 py-2"
+                value={form.parentId}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, parentId: event.target.value }))
+                }
+              >
+                <option value="">Ninguna</option>
+                {tasks.map((task) => (
+                  <option key={task.id} value={task.id}>
+                    {task.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col text-sm md:col-span-2">
+              Descripción
+              <textarea
+                className="mt-1 rounded border px-3 py-2"
+                value={form.description}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, description: event.target.value }))
+                }
+                rows={2}
+              />
+            </label>
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+            >
+              Agregar tarea
+            </button>
+          </div>
+        </form>
+      )}
+
+      {editing && canEdit && (
+        <form
+          onSubmit={handleUpdate}
+          className="grid gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+        >
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-medium text-slate-800">Editar tarea</h3>
+            <button
+              type="button"
+              className="text-sm text-blue-700 underline"
+              onClick={() => setEditing(null)}
+            >
+              Cancelar
+            </button>
+          </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <label className="flex flex-col text-sm">
+              Nombre
+              <input
+                className="mt-1 rounded border px-3 py-2"
+                value={editing.name}
+                onChange={(event) =>
+                  setEditing((prev) =>
+                    prev ? { ...prev, name: event.target.value } : prev
+                  )
+                }
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Responsable
+              <input
+                className="mt-1 rounded border px-3 py-2"
+                value={editing.owner ?? ''}
+                onChange={(event) =>
+                  setEditing((prev) =>
+                    prev ? { ...prev, owner: event.target.value } : prev
+                  )
+                }
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Estado
+              <select
+                className="mt-1 rounded border px-3 py-2"
+                value={editing.status}
+                onChange={(event) =>
+                  setEditing((prev) =>
+                    prev ? { ...prev, status: event.target.value } : prev
+                  )
+                }
+              >
+                {TASK_STATUS.map((status) => (
+                  <option key={status} value={status}>
+                    {status}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col text-sm">
+              Progreso (%)
+              <input
+                type="number"
+                min={0}
+                max={100}
+                className="mt-1 rounded border px-3 py-2"
+                value={editing.progress ?? 0}
+                onChange={(event) =>
+                  setEditing((prev) =>
+                    prev
+                      ? { ...prev, progress: Number(event.target.value) }
+                      : prev
+                  )
+                }
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Fecha inicio
+              <input
+                type="date"
+                className="mt-1 rounded border px-3 py-2"
+                value={editing.startDate.substring(0, 10)}
+                onChange={(event) =>
+                  setEditing((prev) =>
+                    prev ? { ...prev, startDate: event.target.value } : prev
+                  )
+                }
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Fecha término
+              <input
+                type="date"
+                className="mt-1 rounded border px-3 py-2"
+                value={editing.endDate.substring(0, 10)}
+                onChange={(event) =>
+                  setEditing((prev) =>
+                    prev ? { ...prev, endDate: event.target.value } : prev
+                  )
+                }
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Tarea padre
+              <select
+                className="mt-1 rounded border px-3 py-2"
+                value={editing.parentId ?? ''}
+                onChange={(event) =>
+                  setEditing((prev) =>
+                    prev ? { ...prev, parentId: event.target.value || null } : prev
+                  )
+                }
+              >
+                <option value="">Ninguna</option>
+                {availableParents.map((task) => (
+                  <option key={task.id} value={task.id}>
+                    {task.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col text-sm md:col-span-2">
+              Descripción
+              <textarea
+                className="mt-1 rounded border px-3 py-2"
+                value={editing.description ?? ''}
+                onChange={(event) =>
+                  setEditing((prev) =>
+                    prev ? { ...prev, description: event.target.value } : prev
+                  )
+                }
+                rows={2}
+              />
+            </label>
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+            >
+              Actualizar tarea
+            </button>
+          </div>
+        </form>
+      )}
+
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold text-slate-900">Carta Gantt</h3>
+        <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+          <div className="min-w-[720px] space-y-4 p-4">
+            <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-slate-400">
+              <span>{timeline.start.toLocaleDateString()}</span>
+              <span>{timeline.end.toLocaleDateString()}</span>
+            </div>
+            <div className="space-y-3">
+              {flatTasks.map((task) => {
+                const startOffset =
+                  ((parseDate(task.startDate).getTime() - timeline.start.getTime()) /
+                    (1000 * 60 * 60 * 24)) /
+                  totalDuration;
+                const duration =
+                  ((parseDate(task.endDate).getTime() - parseDate(task.startDate).getTime()) /
+                    (1000 * 60 * 60 * 24)) /
+                  totalDuration;
+                const widthPercent = Math.max(duration * 100, 2);
+                const leftPercent = Math.max(startOffset * 100, 0);
+                const color = STATUS_COLOR[task.status] ?? 'bg-slate-400';
+                const progressPercent = Math.min(task.progress ?? 0, 100);
+                const progressWidth = Math.max(
+                  (widthPercent * progressPercent) / 100,
+                  0
+                );
+
+                return (
+                  <div key={task.id} className="space-y-1">
+                    <div className="flex items-center gap-2 text-sm text-slate-600">
+                      <span className="font-medium text-slate-800">
+                        {Array.from({ length: task.depth })
+                          .map(() => '•')
+                          .join(' ')}{' '}
+                        {task.name}
+                      </span>
+                      {task.owner && (
+                        <span className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-500">
+                          {task.owner}
+                        </span>
+                      )}
+                      <span className="text-xs text-slate-400">
+                        {formatDate(task.startDate)} → {formatDate(task.endDate)}
+                      </span>
+                    </div>
+                    <div className="relative h-3 rounded bg-slate-100">
+                      <div
+                        className={`absolute h-3 rounded ${color}`}
+                        style={{
+                          width: `${widthPercent}%`,
+                          left: `${leftPercent}%`,
+                          minWidth: '2%',
+                        }}
+                      />
+                      {task.progress !== null && task.progress !== undefined && (
+                        <div
+                          className="absolute h-3 rounded bg-black/20"
+                          style={{
+                            width: `${progressWidth}%`,
+                            left: `${leftPercent}%`,
+                          }}
+                        />
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+              {flatTasks.length === 0 && (
+                <p className="text-sm text-slate-500">
+                  Aún no hay tareas registradas. Crea hitos para visualizar el plan.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold text-slate-900">Detalle de tareas</h3>
+        <div className="overflow-x-auto rounded-lg border border-slate-200">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium text-slate-600">Tarea</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600">Responsable</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600">Estado</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600">Inicio</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600">Término</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {flatTasks.map((task) => (
+                <tr key={`${task.id}-row`} className="bg-white">
+                  <td className="px-3 py-2">
+                    <span className="font-medium text-slate-800">
+                      {Array.from({ length: task.depth })
+                        .map(() => '•')
+                        .join(' ')}{' '}
+                      {task.name}
+                    </span>
+                    {task.description && (
+                      <p className="text-xs text-slate-500">{task.description}</p>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-slate-600">
+                    {task.owner || '—'}
+                  </td>
+                  <td className="px-3 py-2 text-slate-600">{task.status}</td>
+                  <td className="px-3 py-2 text-slate-600">
+                    {formatDate(task.startDate)}
+                  </td>
+                  <td className="px-3 py-2 text-slate-600">
+                    {formatDate(task.endDate)}
+                  </td>
+                  <td className="px-3 py-2">
+                    {canEdit && (
+                      <button
+                        className="mr-2 rounded bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700"
+                        onClick={() => setEditing(task)}
+                      >
+                        Editar
+                      </button>
+                    )}
+                    {isAdmin && (
+                      <button
+                        className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white"
+                        onClick={() => removeTask(task.id)}
+                      >
+                        Eliminar
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {flatTasks.length === 0 && !loading && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-4 text-center text-slate-500">
+                    No hay tareas registradas.
+                  </td>
+                </tr>
+              )}
+              {loading && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-4 text-center text-slate-500">
+                    Cargando plan…
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/projects/tabs/SecurityTab.tsx
+++ b/web/src/features/projects/tabs/SecurityTab.tsx
@@ -1,0 +1,1408 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import api from '../../../lib/api';
+import { useAuth } from '../../../hooks/useAuth';
+import { getErrorMessage } from '../../../lib/errors';
+
+interface SecurityItem {
+  id: string;
+  systemName: string;
+  userLifecycle?: string | null;
+  rbac?: string | null;
+  mfa?: boolean | null;
+  auditLogs?: boolean | null;
+  backupsRPO?: string | null;
+  backupsRTO?: string | null;
+  tlsInTransit?: boolean | null;
+  encryptionAtRest?: boolean | null;
+  openVulns?: string | null;
+  compliance?: string | null;
+  notes?: string | null;
+}
+
+interface PerformanceItem {
+  id: string;
+  systemName: string;
+  peakUsers?: number | null;
+  latencyMs?: number | null;
+  availabilityPct?: number | null;
+  incidents90d?: number | null;
+  topRootCause?: string | null;
+  capacityInfo?: string | null;
+  scalability?: number | null;
+  notes?: string | null;
+}
+
+interface CostItem {
+  id: string;
+  systemName: string;
+  model: string;
+  usersLicenses?: number | null;
+  costAnnual?: number | null;
+  implUSD?: number | null;
+  infraUSD?: number | null;
+  supportUSD?: number | null;
+  otherUSD?: number | null;
+  tco3y?: number | null;
+}
+
+interface SecurityTabProps {
+  projectId: string;
+}
+
+const defaultSecurityForm = {
+  systemName: '',
+  userLifecycle: '',
+  rbac: '',
+  mfa: 'true',
+  auditLogs: 'true',
+  backupsRPO: '',
+  backupsRTO: '',
+  tlsInTransit: 'true',
+  encryptionAtRest: 'true',
+  openVulns: '',
+  compliance: '',
+  notes: '',
+};
+
+const defaultPerformanceForm = {
+  systemName: '',
+  peakUsers: '',
+  latencyMs: '',
+  availabilityPct: '',
+  incidents90d: '',
+  topRootCause: '',
+  capacityInfo: '',
+  scalability: '',
+  notes: '',
+};
+
+const defaultCostForm = {
+  systemName: '',
+  model: '',
+  usersLicenses: '',
+  costAnnual: '',
+  implUSD: '',
+  infraUSD: '',
+  supportUSD: '',
+  otherUSD: '',
+};
+
+export default function SecurityTab({ projectId }: SecurityTabProps) {
+  const { role } = useAuth();
+  const canEdit = useMemo(() => ['admin', 'consultor'].includes(role), [role]);
+  const isAdmin = role === 'admin';
+
+  const [securityItems, setSecurityItems] = useState<SecurityItem[]>([]);
+  const [securityForm, setSecurityForm] = useState(defaultSecurityForm);
+  const [editingSecurity, setEditingSecurity] = useState<SecurityItem | null>(null);
+
+  const [performanceItems, setPerformanceItems] = useState<PerformanceItem[]>([]);
+  const [performanceForm, setPerformanceForm] = useState(defaultPerformanceForm);
+  const [editingPerformance, setEditingPerformance] = useState<PerformanceItem | null>(null);
+
+  const [costItems, setCostItems] = useState<CostItem[]>([]);
+  const [costForm, setCostForm] = useState(defaultCostForm);
+  const [editingCost, setEditingCost] = useState<CostItem | null>(null);
+
+  const [error, setError] = useState<string | null>(null);
+
+  const loadSecurity = useCallback(async () => {
+    try {
+      const response = await api.get<SecurityItem[]>(
+        `/systems/security/${projectId}`
+      );
+      setSecurityItems(response.data ?? []);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo cargar la postura de seguridad'));
+    }
+  }, [projectId]);
+
+  const loadPerformance = useCallback(async () => {
+    try {
+      const response = await api.get<PerformanceItem[]>(
+        `/systems/performance/${projectId}`
+      );
+      setPerformanceItems(response.data ?? []);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo cargar el rendimiento de sistemas'));
+    }
+  }, [projectId]);
+
+  const loadCosts = useCallback(async () => {
+    try {
+      const response = await api.get<CostItem[]>(`/systems/costs/${projectId}`);
+      setCostItems(response.data ?? []);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudieron cargar los costos'));
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void loadSecurity();
+    void loadPerformance();
+    void loadCosts();
+  }, [loadSecurity, loadPerformance, loadCosts]);
+
+  const handleCreateSecurity = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+    try {
+      await api.post(`/systems/security/${projectId}`, {
+        systemName: securityForm.systemName,
+        userLifecycle: securityForm.userLifecycle || undefined,
+        rbac: securityForm.rbac || undefined,
+        mfa: securityForm.mfa === 'true',
+        auditLogs: securityForm.auditLogs === 'true',
+        backupsRPO: securityForm.backupsRPO || undefined,
+        backupsRTO: securityForm.backupsRTO || undefined,
+        tlsInTransit: securityForm.tlsInTransit === 'true',
+        encryptionAtRest: securityForm.encryptionAtRest === 'true',
+        openVulns: securityForm.openVulns || undefined,
+        compliance: securityForm.compliance || undefined,
+        notes: securityForm.notes || undefined,
+      });
+      setSecurityForm(defaultSecurityForm);
+      await loadSecurity();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo registrar la postura de seguridad'));
+    }
+  };
+
+  const handleUpdateSecurity = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingSecurity) return;
+    try {
+      await api.put(`/systems/security/${projectId}/${editingSecurity.id}`, {
+        systemName: editingSecurity.systemName,
+        userLifecycle: editingSecurity.userLifecycle || undefined,
+        rbac: editingSecurity.rbac || undefined,
+        mfa: editingSecurity.mfa ?? undefined,
+        auditLogs: editingSecurity.auditLogs ?? undefined,
+        backupsRPO: editingSecurity.backupsRPO || undefined,
+        backupsRTO: editingSecurity.backupsRTO || undefined,
+        tlsInTransit: editingSecurity.tlsInTransit ?? undefined,
+        encryptionAtRest: editingSecurity.encryptionAtRest ?? undefined,
+        openVulns: editingSecurity.openVulns || undefined,
+        compliance: editingSecurity.compliance || undefined,
+        notes: editingSecurity.notes || undefined,
+      });
+      setEditingSecurity(null);
+      await loadSecurity();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo actualizar la postura de seguridad'));
+    }
+  };
+
+  const handleCreatePerformance = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+    try {
+      await api.post(`/systems/performance/${projectId}`, {
+        systemName: performanceForm.systemName,
+        peakUsers: performanceForm.peakUsers ? Number(performanceForm.peakUsers) : undefined,
+        latencyMs: performanceForm.latencyMs ? Number(performanceForm.latencyMs) : undefined,
+        availabilityPct: performanceForm.availabilityPct
+          ? Number(performanceForm.availabilityPct)
+          : undefined,
+        incidents90d: performanceForm.incidents90d
+          ? Number(performanceForm.incidents90d)
+          : undefined,
+        topRootCause: performanceForm.topRootCause || undefined,
+        capacityInfo: performanceForm.capacityInfo || undefined,
+        scalability: performanceForm.scalability ? Number(performanceForm.scalability) : undefined,
+        notes: performanceForm.notes || undefined,
+      });
+      setPerformanceForm(defaultPerformanceForm);
+      await loadPerformance();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo registrar el desempeño del sistema'));
+    }
+  };
+
+  const handleUpdatePerformance = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingPerformance) return;
+    try {
+      await api.put(`/systems/performance/${projectId}/${editingPerformance.id}`, {
+        systemName: editingPerformance.systemName,
+        peakUsers: editingPerformance.peakUsers ?? undefined,
+        latencyMs: editingPerformance.latencyMs ?? undefined,
+        availabilityPct: editingPerformance.availabilityPct ?? undefined,
+        incidents90d: editingPerformance.incidents90d ?? undefined,
+        topRootCause: editingPerformance.topRootCause || undefined,
+        capacityInfo: editingPerformance.capacityInfo || undefined,
+        scalability: editingPerformance.scalability ?? undefined,
+        notes: editingPerformance.notes || undefined,
+      });
+      setEditingPerformance(null);
+      await loadPerformance();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo actualizar el desempeño del sistema'));
+    }
+  };
+
+  const handleCreateCost = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+    try {
+      await api.post(`/systems/costs/${projectId}`, {
+        systemName: costForm.systemName,
+        model: costForm.model,
+        usersLicenses: costForm.usersLicenses ? Number(costForm.usersLicenses) : undefined,
+        costAnnual: costForm.costAnnual ? Number(costForm.costAnnual) : undefined,
+        implUSD: costForm.implUSD ? Number(costForm.implUSD) : undefined,
+        infraUSD: costForm.infraUSD ? Number(costForm.infraUSD) : undefined,
+        supportUSD: costForm.supportUSD ? Number(costForm.supportUSD) : undefined,
+        otherUSD: costForm.otherUSD ? Number(costForm.otherUSD) : undefined,
+      });
+      setCostForm(defaultCostForm);
+      await loadCosts();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo registrar el costo'));
+    }
+  };
+
+  const handleUpdateCost = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingCost) return;
+    try {
+      await api.put(`/systems/costs/${projectId}/${editingCost.id}`, {
+        systemName: editingCost.systemName,
+        model: editingCost.model,
+        usersLicenses: editingCost.usersLicenses ?? undefined,
+        costAnnual: editingCost.costAnnual ?? undefined,
+        implUSD: editingCost.implUSD ?? undefined,
+        infraUSD: editingCost.infraUSD ?? undefined,
+        supportUSD: editingCost.supportUSD ?? undefined,
+        otherUSD: editingCost.otherUSD ?? undefined,
+      });
+      setEditingCost(null);
+      await loadCosts();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo actualizar el costo'));
+    }
+  };
+
+  const removeSecurity = async (id: string) => {
+    if (!isAdmin) return;
+    try {
+      await api.delete(`/systems/security/${projectId}/${id}`);
+      await loadSecurity();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo eliminar el registro de seguridad'));
+    }
+  };
+
+  const removePerformance = async (id: string) => {
+    if (!isAdmin) return;
+    try {
+      await api.delete(`/systems/performance/${projectId}/${id}`);
+      await loadPerformance();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo eliminar el registro de desempeño'));
+    }
+  };
+
+  const removeCost = async (id: string) => {
+    if (!isAdmin) return;
+    try {
+      await api.delete(`/systems/costs/${projectId}/${id}`);
+      await loadCosts();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo eliminar el registro de costos'));
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Seguridad</h2>
+        <p className="text-sm text-slate-500">
+          Monitorea controles, desempeño y costos asociados a los sistemas auditados.
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>
+      )}
+
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900">Postura de seguridad</h3>
+          <p className="text-sm text-slate-500">
+            Evalúa la madurez de controles y vulnerabilidades abiertas por sistema.
+          </p>
+        </header>
+        {canEdit && !editingSecurity && (
+          <form
+            onSubmit={handleCreateSecurity}
+            className="grid gap-3 rounded-lg border border-slate-200 p-4"
+          >
+            <h4 className="text-base font-medium text-slate-800">Nuevo registro</h4>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.systemName}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      systemName: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Ciclo de vida de usuarios
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.userLifecycle}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      userLifecycle: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Modelo RBAC
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.rbac}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      rbac: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                MFA habilitado
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.mfa}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      mfa: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Auditoría habilitada
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.auditLogs}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      auditLogs: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                RPO backups
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.backupsRPO}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      backupsRPO: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                RTO backups
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.backupsRTO}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      backupsRTO: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                TLS en tránsito
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.tlsInTransit}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      tlsInTransit: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Cifrado en reposo
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.encryptionAtRest}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      encryptionAtRest: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Vulnerabilidades abiertas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.openVulns}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      openVulns: event.target.value,
+                    }))
+                  }
+                  rows={2}
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Cumplimiento y notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={securityForm.compliance}
+                  onChange={(event) =>
+                    setSecurityForm((prev) => ({
+                      ...prev,
+                      compliance: event.target.value,
+                    }))
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Registrar postura
+              </button>
+            </div>
+          </form>
+        )}
+
+        {editingSecurity && canEdit && (
+          <form
+            onSubmit={handleUpdateSecurity}
+            className="grid gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+          >
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-medium text-slate-800">Editar registro</h4>
+              <button
+                type="button"
+                className="text-sm text-blue-700 underline"
+                onClick={() => setEditingSecurity(null)}
+              >
+                Cancelar
+              </button>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.systemName}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, systemName: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Ciclo de vida de usuarios
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.userLifecycle ?? ''}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, userLifecycle: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Modelo RBAC
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.rbac ?? ''}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, rbac: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                MFA habilitado
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.mfa ? 'true' : 'false'}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, mfa: event.target.value === 'true' } : prev
+                    )
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Auditoría habilitada
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.auditLogs ? 'true' : 'false'}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, auditLogs: event.target.value === 'true' } : prev
+                    )
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                RPO backups
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.backupsRPO ?? ''}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, backupsRPO: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                RTO backups
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.backupsRTO ?? ''}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, backupsRTO: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                TLS en tránsito
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.tlsInTransit ? 'true' : 'false'}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, tlsInTransit: event.target.value === 'true' } : prev
+                    )
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Cifrado en reposo
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.encryptionAtRest ? 'true' : 'false'}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev
+                        ? { ...prev, encryptionAtRest: event.target.value === 'true' }
+                        : prev
+                    )
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Vulnerabilidades abiertas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.openVulns ?? ''}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, openVulns: event.target.value } : prev
+                    )
+                  }
+                  rows={2}
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Cumplimiento y notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingSecurity.compliance ?? ''}
+                  onChange={(event) =>
+                    setEditingSecurity((prev) =>
+                      prev ? { ...prev, compliance: event.target.value } : prev
+                    )
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Actualizar postura
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="space-y-2">
+          {securityItems.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-wrap items-start justify-between gap-2 rounded border border-slate-200 bg-slate-50 p-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-slate-800">{item.systemName}</p>
+                <p className="text-xs text-slate-500">
+                  MFA: {item.mfa ? 'Sí' : 'No'} · Logs: {item.auditLogs ? 'Sí' : 'No'} · TLS: {item.tlsInTransit ? 'Sí' : 'No'}
+                </p>
+                {item.openVulns && (
+                  <p className="text-xs text-red-500">Vulnerabilidades: {item.openVulns}</p>
+                )}
+                {item.notes && (
+                  <p className="text-xs text-slate-500">{item.notes}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {canEdit && (
+                  <button
+                    className="rounded bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                    onClick={() => setEditingSecurity(item)}
+                  >
+                    Editar
+                  </button>
+                )}
+                {isAdmin && (
+                  <button
+                    className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white"
+                    onClick={() => removeSecurity(item.id)}
+                  >
+                    Eliminar
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {securityItems.length === 0 && (
+            <p className="text-sm text-slate-500">No hay registros de seguridad.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900">Performance de sistemas</h3>
+          <p className="text-sm text-slate-500">
+            Registra métricas operacionales, incidentes y escalabilidad.
+          </p>
+        </header>
+        {canEdit && !editingPerformance && (
+          <form
+            onSubmit={handleCreatePerformance}
+            className="grid gap-3 rounded-lg border border-slate-200 p-4"
+          >
+            <h4 className="text-base font-medium text-slate-800">Nuevo registro</h4>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={performanceForm.systemName}
+                  onChange={(event) =>
+                    setPerformanceForm((prev) => ({
+                      ...prev,
+                      systemName: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Usuarios pico
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={performanceForm.peakUsers}
+                  onChange={(event) =>
+                    setPerformanceForm((prev) => ({
+                      ...prev,
+                      peakUsers: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Latencia (ms)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={performanceForm.latencyMs}
+                  onChange={(event) =>
+                    setPerformanceForm((prev) => ({
+                      ...prev,
+                      latencyMs: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Disponibilidad (%)
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="0.1"
+                  className="mt-1 rounded border px-3 py-2"
+                  value={performanceForm.availabilityPct}
+                  onChange={(event) =>
+                    setPerformanceForm((prev) => ({
+                      ...prev,
+                      availabilityPct: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Incidentes 90 días
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={performanceForm.incidents90d}
+                  onChange={(event) =>
+                    setPerformanceForm((prev) => ({
+                      ...prev,
+                      incidents90d: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Principal causa raíz
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={performanceForm.topRootCause}
+                  onChange={(event) =>
+                    setPerformanceForm((prev) => ({
+                      ...prev,
+                      topRootCause: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Información de capacidad
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={performanceForm.capacityInfo}
+                  onChange={(event) =>
+                    setPerformanceForm((prev) => ({
+                      ...prev,
+                      capacityInfo: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Escalabilidad (1-5)
+                <input
+                  type="number"
+                  min={1}
+                  max={5}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={performanceForm.scalability}
+                  onChange={(event) =>
+                    setPerformanceForm((prev) => ({
+                      ...prev,
+                      scalability: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={performanceForm.notes}
+                  onChange={(event) =>
+                    setPerformanceForm((prev) => ({
+                      ...prev,
+                      notes: event.target.value,
+                    }))
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Registrar rendimiento
+              </button>
+            </div>
+          </form>
+        )}
+
+        {editingPerformance && canEdit && (
+          <form
+            onSubmit={handleUpdatePerformance}
+            className="grid gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+          >
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-medium text-slate-800">Editar registro</h4>
+              <button
+                type="button"
+                className="text-sm text-blue-700 underline"
+                onClick={() => setEditingPerformance(null)}
+              >
+                Cancelar
+              </button>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingPerformance.systemName}
+                  onChange={(event) =>
+                    setEditingPerformance((prev) =>
+                      prev ? { ...prev, systemName: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Usuarios pico
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingPerformance.peakUsers ?? ''}
+                  onChange={(event) =>
+                    setEditingPerformance((prev) =>
+                      prev ? { ...prev, peakUsers: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Latencia (ms)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingPerformance.latencyMs ?? ''}
+                  onChange={(event) =>
+                    setEditingPerformance((prev) =>
+                      prev ? { ...prev, latencyMs: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Disponibilidad (%)
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="0.1"
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingPerformance.availabilityPct ?? ''}
+                  onChange={(event) =>
+                    setEditingPerformance((prev) =>
+                      prev
+                        ? { ...prev, availabilityPct: Number(event.target.value) }
+                        : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Incidentes 90 días
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingPerformance.incidents90d ?? ''}
+                  onChange={(event) =>
+                    setEditingPerformance((prev) =>
+                      prev ? { ...prev, incidents90d: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Principal causa raíz
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingPerformance.topRootCause ?? ''}
+                  onChange={(event) =>
+                    setEditingPerformance((prev) =>
+                      prev ? { ...prev, topRootCause: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Información de capacidad
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingPerformance.capacityInfo ?? ''}
+                  onChange={(event) =>
+                    setEditingPerformance((prev) =>
+                      prev ? { ...prev, capacityInfo: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Escalabilidad (1-5)
+                <input
+                  type="number"
+                  min={1}
+                  max={5}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingPerformance.scalability ?? ''}
+                  onChange={(event) =>
+                    setEditingPerformance((prev) =>
+                      prev ? { ...prev, scalability: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingPerformance.notes ?? ''}
+                  onChange={(event) =>
+                    setEditingPerformance((prev) =>
+                      prev ? { ...prev, notes: event.target.value } : prev
+                    )
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Actualizar rendimiento
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="space-y-2">
+          {performanceItems.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-wrap items-start justify-between gap-2 rounded border border-slate-200 bg-slate-50 p-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-slate-800">{item.systemName}</p>
+                <p className="text-xs text-slate-500">
+                  Disponibilidad: {item.availabilityPct ?? 'N/D'}% · Incidentes: {item.incidents90d ?? 'N/D'}
+                </p>
+                {item.topRootCause && (
+                  <p className="text-xs text-slate-500">Causa raíz: {item.topRootCause}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {canEdit && (
+                  <button
+                    className="rounded bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                    onClick={() => setEditingPerformance(item)}
+                  >
+                    Editar
+                  </button>
+                )}
+                {isAdmin && (
+                  <button
+                    className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white"
+                    onClick={() => removePerformance(item.id)}
+                  >
+                    Eliminar
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {performanceItems.length === 0 && (
+            <p className="text-sm text-slate-500">No hay registros de performance.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900">Costos y licenciamiento</h3>
+          <p className="text-sm text-slate-500">
+            Controla el modelo de licenciamiento y el costo total de propiedad estimado.
+          </p>
+        </header>
+        {canEdit && !editingCost && (
+          <form
+            onSubmit={handleCreateCost}
+            className="grid gap-3 rounded-lg border border-slate-200 p-4"
+          >
+            <h4 className="text-base font-medium text-slate-800">Nuevo registro</h4>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={costForm.systemName}
+                  onChange={(event) =>
+                    setCostForm((prev) => ({
+                      ...prev,
+                      systemName: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Modelo de licenciamiento
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={costForm.model}
+                  onChange={(event) =>
+                    setCostForm((prev) => ({
+                      ...prev,
+                      model: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Usuarios / licencias
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={costForm.usersLicenses}
+                  onChange={(event) =>
+                    setCostForm((prev) => ({
+                      ...prev,
+                      usersLicenses: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Costo anual (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={costForm.costAnnual}
+                  onChange={(event) =>
+                    setCostForm((prev) => ({
+                      ...prev,
+                      costAnnual: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Implementación (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={costForm.implUSD}
+                  onChange={(event) =>
+                    setCostForm((prev) => ({
+                      ...prev,
+                      implUSD: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Infraestructura (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={costForm.infraUSD}
+                  onChange={(event) =>
+                    setCostForm((prev) => ({
+                      ...prev,
+                      infraUSD: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Soporte (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={costForm.supportUSD}
+                  onChange={(event) =>
+                    setCostForm((prev) => ({
+                      ...prev,
+                      supportUSD: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Otros costos (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={costForm.otherUSD}
+                  onChange={(event) =>
+                    setCostForm((prev) => ({
+                      ...prev,
+                      otherUSD: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Registrar costo
+              </button>
+            </div>
+          </form>
+        )}
+
+        {editingCost && canEdit && (
+          <form
+            onSubmit={handleUpdateCost}
+            className="grid gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+          >
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-medium text-slate-800">Editar registro</h4>
+              <button
+                type="button"
+                className="text-sm text-blue-700 underline"
+                onClick={() => setEditingCost(null)}
+              >
+                Cancelar
+              </button>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCost.systemName}
+                  onChange={(event) =>
+                    setEditingCost((prev) =>
+                      prev ? { ...prev, systemName: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Modelo de licenciamiento
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCost.model}
+                  onChange={(event) =>
+                    setEditingCost((prev) =>
+                      prev ? { ...prev, model: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Usuarios / licencias
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCost.usersLicenses ?? ''}
+                  onChange={(event) =>
+                    setEditingCost((prev) =>
+                      prev ? { ...prev, usersLicenses: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Costo anual (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCost.costAnnual ?? ''}
+                  onChange={(event) =>
+                    setEditingCost((prev) =>
+                      prev ? { ...prev, costAnnual: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Implementación (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCost.implUSD ?? ''}
+                  onChange={(event) =>
+                    setEditingCost((prev) =>
+                      prev ? { ...prev, implUSD: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Infraestructura (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCost.infraUSD ?? ''}
+                  onChange={(event) =>
+                    setEditingCost((prev) =>
+                      prev ? { ...prev, infraUSD: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Soporte (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCost.supportUSD ?? ''}
+                  onChange={(event) =>
+                    setEditingCost((prev) =>
+                      prev ? { ...prev, supportUSD: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Otros costos (USD)
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCost.otherUSD ?? ''}
+                  onChange={(event) =>
+                    setEditingCost((prev) =>
+                      prev ? { ...prev, otherUSD: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Actualizar costo
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="space-y-2">
+          {costItems.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-wrap items-start justify-between gap-2 rounded border border-slate-200 bg-slate-50 p-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-slate-800">{item.systemName}</p>
+                <p className="text-xs text-slate-500">
+                  Modelo: {item.model} · Usuarios: {item.usersLicenses ?? 'N/D'} · TCO 3y: ${item.tco3y?.toLocaleString('es-CL') ?? 'N/D'}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {canEdit && (
+                  <button
+                    className="rounded bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                    onClick={() => setEditingCost(item)}
+                  >
+                    Editar
+                  </button>
+                )}
+                {isAdmin && (
+                  <button
+                    className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white"
+                    onClick={() => removeCost(item.id)}
+                  >
+                    Eliminar
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {costItems.length === 0 && (
+            <p className="text-sm text-slate-500">No hay registros de costos.</p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/features/projects/tabs/SummaryTab.tsx
+++ b/web/src/features/projects/tabs/SummaryTab.tsx
@@ -1,0 +1,359 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import api from '../../../lib/api';
+import { getErrorMessage } from '../../../lib/errors';
+
+interface SummaryResponse {
+  project: {
+    id: string;
+    name: string;
+    status: string;
+    startDate?: string | null;
+    endDate?: string | null;
+    company?: { id: string; name: string } | null;
+  };
+  sections: {
+    preKickoff: { total: number; pending: number; overdue: number };
+    surveys: {
+      total: number;
+      active: number;
+      questions: number;
+      responses: number;
+    };
+    interviews: { total: number };
+    processes: { deliverables: number; featuresEnabled: number };
+    systems: {
+      inventory: number;
+      integrations: number;
+      coverage: number;
+      gaps: number;
+      averageCoverage: number | null;
+      dataQuality: number;
+    };
+    security: {
+      posture: number;
+      openVulnerabilities: number;
+      performance: number;
+      costs: number;
+      totalTco: number;
+    };
+    risks: { total: number; critical: number };
+    findings: { total: number; open: number };
+    poc: { total: number; active: number };
+    decisions: { total: number };
+    kpis: {
+      total: number;
+      latest: { id: string; name: string; value: number; unit?: string | null; date: string } | null;
+    };
+    gantt: {
+      total: number;
+      late: number;
+      next: { id: string; name: string; startDate: string } | null;
+    };
+  };
+}
+
+interface SummaryTabProps {
+  projectId: string;
+}
+
+const TAB_PATHS: Record<string, string> = {
+  preKickoff: 'prekickoff',
+  surveys: 'surveys',
+  interviews: 'interviews',
+  processes: 'procesos',
+  systems: 'systems',
+  security: 'security',
+  risks: 'risks',
+  findings: 'findings',
+  poc: 'poc',
+  decisions: 'decisions',
+  kpis: 'kpis',
+  export: 'export',
+  gantt: 'plan',
+};
+
+const formatDate = (value?: string | null) =>
+  value ? new Date(value).toLocaleDateString() : 'Sin definir';
+
+const formatPercent = (value: number | null) =>
+  typeof value === 'number' ? `${Math.round(value)}%` : 'Sin datos';
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('es-CL', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+export default function SummaryTab({ projectId }: SummaryTabProps) {
+  const navigate = useNavigate();
+  const [summary, setSummary] = useState<SummaryResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadSummary = useCallback(async () => {
+    if (!projectId) return;
+    setLoading(true);
+    try {
+      const response = await api.get<SummaryResponse>(
+        `/projects/${projectId}/summary`
+      );
+      setSummary(response.data ?? null);
+      setError(null);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo obtener el resumen'));
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void loadSummary();
+  }, [loadSummary]);
+
+  const cards = useMemo(() => {
+    if (!summary) return [];
+    const { sections } = summary;
+    return [
+      {
+        key: 'preKickoff',
+        title: 'Pre-kickoff',
+        description: 'Estado del checklist de información previa.',
+        tab: TAB_PATHS.preKickoff,
+        metrics: [
+          { label: 'Pendientes', value: sections.preKickoff.pending },
+          { label: 'Atrasados', value: sections.preKickoff.overdue },
+          { label: 'Total', value: sections.preKickoff.total },
+        ],
+      },
+      {
+        key: 'surveys',
+        title: 'Encuestas',
+        description: 'Mediciones a stakeholders y tasa de respuesta.',
+        tab: TAB_PATHS.surveys,
+        metrics: [
+          { label: 'Activas', value: sections.surveys.active },
+          { label: 'Respuestas', value: sections.surveys.responses },
+          { label: 'Preguntas', value: sections.surveys.questions },
+        ],
+      },
+      {
+        key: 'interviews',
+        title: 'Entrevistas',
+        description: 'Registro de sesiones realizadas.',
+        tab: TAB_PATHS.interviews,
+        metrics: [
+          { label: 'Entrevistas', value: sections.interviews.total },
+        ],
+      },
+      {
+        key: 'processes',
+        title: 'Procesos',
+        description: 'Entregables y módulos habilitados.',
+        tab: TAB_PATHS.processes,
+        metrics: [
+          { label: 'Entregables', value: sections.processes.deliverables },
+          { label: 'Features', value: sections.processes.featuresEnabled },
+        ],
+      },
+      {
+        key: 'systems',
+        title: 'Sistemas',
+        description: 'Inventario y cobertura funcional.',
+        tab: TAB_PATHS.systems,
+        metrics: [
+          { label: 'Inventario', value: sections.systems.inventory },
+          { label: 'Integraciones', value: sections.systems.integrations },
+          {
+            label: 'Cobertura',
+            value: formatPercent(sections.systems.averageCoverage),
+          },
+        ],
+      },
+      {
+        key: 'security',
+        title: 'Seguridad',
+        description: 'Salud de controles y costos asociados.',
+        tab: TAB_PATHS.security,
+        metrics: [
+          { label: 'Evaluaciones', value: sections.security.posture },
+          { label: 'Vulnerabilidades', value: sections.security.openVulnerabilities },
+          { label: 'TCO 3 años', value: formatCurrency(sections.security.totalTco) },
+        ],
+      },
+      {
+        key: 'risks',
+        title: 'Riesgos',
+        description: 'Mapa de riesgos priorizados.',
+        tab: TAB_PATHS.risks,
+        metrics: [
+          { label: 'Totales', value: sections.risks.total },
+          { label: 'Críticos', value: sections.risks.critical },
+        ],
+      },
+      {
+        key: 'findings',
+        title: 'Hallazgos',
+        description: 'Hallazgos pendientes y cerrados.',
+        tab: TAB_PATHS.findings,
+        metrics: [
+          { label: 'Totales', value: sections.findings.total },
+          { label: 'Abiertos', value: sections.findings.open },
+        ],
+      },
+      {
+        key: 'poc',
+        title: 'POC',
+        description: 'Pruebas de concepto en curso.',
+        tab: TAB_PATHS.poc,
+        metrics: [
+          { label: 'Total', value: sections.poc.total },
+          { label: 'Activas', value: sections.poc.active },
+        ],
+      },
+      {
+        key: 'decisions',
+        title: 'Decisiones',
+        description: 'Bitácora de decisiones clave.',
+        tab: TAB_PATHS.decisions,
+        metrics: [
+          { label: 'Registradas', value: sections.decisions.total },
+        ],
+      },
+      {
+        key: 'kpis',
+        title: 'KPIs',
+        description: 'Seguimiento de indicadores críticos.',
+        tab: TAB_PATHS.kpis,
+        metrics: [
+          { label: 'Indicadores', value: sections.kpis.total },
+          {
+            label: 'Último KPI',
+            value: sections.kpis.latest
+              ? `${sections.kpis.latest.name}: ${sections.kpis.latest.value} ${
+                  sections.kpis.latest.unit ?? ''
+                }`
+              : 'Sin datos',
+          },
+        ],
+      },
+      {
+        key: 'plan',
+        title: 'Plan del proyecto',
+        description: 'Seguimiento del plan y tareas críticas.',
+        tab: TAB_PATHS.plan,
+        metrics: [
+          { label: 'Tareas', value: sections.gantt.total },
+          { label: 'Atrasadas', value: sections.gantt.late },
+          {
+            label: 'Próximo hito',
+            value: sections.gantt.next
+              ? `${sections.gantt.next.name} · ${formatDate(
+                  sections.gantt.next.startDate
+                )}`
+              : 'Sin próximo hito',
+          },
+        ],
+      },
+      {
+        key: 'export',
+        title: 'Exportación',
+        description: 'Reportes ejecutivos listos para compartir.',
+        tab: TAB_PATHS.export,
+        metrics: [
+          { label: 'Descargar', value: 'Zip + PDF' },
+        ],
+      },
+    ];
+  }, [summary]);
+
+  const goToTab = (tabPath: string) => {
+    if (!projectId) return;
+    const path = tabPath ? `/projects/${projectId}/${tabPath}` : `/projects/${projectId}`;
+    navigate(path);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Resumen ejecutivo</h2>
+        <p className="text-sm text-slate-500">
+          Vista rápida del estado del proyecto y accesos directos a cada módulo.
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </p>
+      )}
+
+      {loading && (
+        <p className="rounded border border-slate-200 bg-white p-3 text-sm text-slate-500">
+          Cargando resumen del proyecto…
+        </p>
+      )}
+
+      {summary && (
+        <div className="space-y-4">
+          <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-900">
+                  {summary.project.company?.name ?? 'Proyecto'} · {summary.project.name}
+                </h3>
+                <p className="text-sm text-slate-500">
+                  Estado: {summary.project.status}
+                </p>
+              </div>
+              <div className="text-sm text-slate-500">
+                <p>Inicio: {formatDate(summary.project.startDate)}</p>
+                <p>Cierre: {formatDate(summary.project.endDate)}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-3">
+            {cards.map((card) => (
+              <div
+                key={card.key}
+                className="flex h-full flex-col justify-between rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+              >
+                <div className="space-y-2">
+                  <h4 className="text-base font-semibold text-slate-900">
+                    {card.title}
+                  </h4>
+                  <p className="text-sm text-slate-500">{card.description}</p>
+                  <ul className="space-y-1 text-sm text-slate-600">
+                    {card.metrics.map((metric) => (
+                      <li key={`${card.key}-${metric.label}`}>
+                        <span className="font-medium text-slate-800">
+                          {metric.label}:
+                        </span>{' '}
+                        {metric.value}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <button
+                  className="mt-4 inline-flex items-center justify-center rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white"
+                  onClick={() => goToTab(card.tab)}
+                >
+                  Ir a sección
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!loading && !summary && !error && (
+        <p className="text-sm text-slate-500">
+          Selecciona un proyecto para ver su resumen ejecutivo.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/projects/tabs/SystemsTab.tsx
+++ b/web/src/features/projects/tabs/SystemsTab.tsx
@@ -1,0 +1,1565 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import api from '../../../lib/api';
+import { useAuth } from '../../../hooks/useAuth';
+import { getErrorMessage } from '../../../lib/errors';
+
+interface InventoryItem {
+  id: string;
+  systemName: string;
+  type: string;
+  ownerArea?: string | null;
+  usersActive?: number | null;
+  criticality?: string | null;
+  notes?: string | null;
+}
+
+interface CoverageItem {
+  id: string;
+  process: string;
+  subProcess?: string | null;
+  systemNameRef?: string | null;
+  coverage: number;
+  hasGap: boolean;
+  gapDesc?: string | null;
+  owner?: string | null;
+}
+
+interface IntegrationItem {
+  id: string;
+  source: string;
+  target: string;
+  type: string;
+  periodicity?: string | null;
+  dailyVolume?: number | null;
+  format?: string | null;
+  notes?: string | null;
+}
+
+interface DataQualityItem {
+  id: string;
+  systemName: string;
+  entity: string;
+  hasCriticalFields: boolean;
+  dataQuality: number;
+  hasBusinessRules: boolean;
+  historyYears?: number | null;
+  notes?: string | null;
+}
+
+interface SystemsTabProps {
+  projectId: string;
+}
+
+const defaultInventoryForm = {
+  systemName: '',
+  type: '',
+  ownerArea: '',
+  usersActive: '',
+  criticality: '',
+  notes: '',
+};
+
+const defaultCoverageForm = {
+  process: '',
+  subProcess: '',
+  systemNameRef: '',
+  coverage: 80,
+  hasGap: 'false',
+  gapDesc: '',
+  owner: '',
+};
+
+const defaultIntegrationForm = {
+  source: '',
+  target: '',
+  type: '',
+  periodicity: '',
+  dailyVolume: '',
+  format: '',
+  notes: '',
+};
+
+const defaultDataQualityForm = {
+  systemName: '',
+  entity: '',
+  hasCriticalFields: 'true',
+  dataQuality: 80,
+  hasBusinessRules: 'true',
+  historyYears: '',
+  notes: '',
+};
+
+export default function SystemsTab({ projectId }: SystemsTabProps) {
+  const { role } = useAuth();
+  const canEdit = useMemo(() => ['admin', 'consultor'].includes(role), [role]);
+  const isAdmin = role === 'admin';
+
+  const [inventory, setInventory] = useState<InventoryItem[]>([]);
+  const [inventoryForm, setInventoryForm] = useState(defaultInventoryForm);
+  const [editingInventory, setEditingInventory] = useState<InventoryItem | null>(null);
+
+  const [coverage, setCoverage] = useState<CoverageItem[]>([]);
+  const [coverageForm, setCoverageForm] = useState(defaultCoverageForm);
+  const [editingCoverage, setEditingCoverage] = useState<CoverageItem | null>(null);
+
+  const [integrations, setIntegrations] = useState<IntegrationItem[]>([]);
+  const [integrationForm, setIntegrationForm] = useState(defaultIntegrationForm);
+  const [editingIntegration, setEditingIntegration] = useState<IntegrationItem | null>(null);
+
+  const [dataQuality, setDataQuality] = useState<DataQualityItem[]>([]);
+  const [dataQualityForm, setDataQualityForm] = useState(defaultDataQualityForm);
+  const [editingDataQuality, setEditingDataQuality] = useState<DataQualityItem | null>(null);
+
+  const [error, setError] = useState<string | null>(null);
+
+  const loadInventory = useCallback(async () => {
+    try {
+      const response = await api.get<InventoryItem[]>(
+        `/systems/inventory/${projectId}`
+      );
+      setInventory(response.data ?? []);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo cargar el inventario'));
+    }
+  }, [projectId]);
+
+  const loadCoverage = useCallback(async () => {
+    try {
+      const response = await api.get<CoverageItem[]>(
+        `/systems/coverage/${projectId}`
+      );
+      setCoverage(response.data ?? []);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo cargar la cobertura de procesos'));
+    }
+  }, [projectId]);
+
+  const loadIntegrations = useCallback(async () => {
+    try {
+      const response = await api.get<IntegrationItem[]>(
+        `/systems/integrations/${projectId}`
+      );
+      setIntegrations(response.data ?? []);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudieron cargar las integraciones'));
+    }
+  }, [projectId]);
+
+  const loadDataQuality = useCallback(async () => {
+    try {
+      const response = await api.get<DataQualityItem[]>(
+        `/systems/data-quality/${projectId}`
+      );
+      setDataQuality(response.data ?? []);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo cargar la calidad de datos'));
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void loadInventory();
+    void loadCoverage();
+    void loadIntegrations();
+    void loadDataQuality();
+  }, [loadInventory, loadCoverage, loadIntegrations, loadDataQuality]);
+
+  const coverageGroups = useMemo(() => {
+    const groups = new Map<string, CoverageItem[]>();
+    coverage.forEach((item) => {
+      const key = item.process;
+      if (!groups.has(key)) {
+        groups.set(key, []);
+      }
+      groups.get(key)!.push(item);
+    });
+    groups.forEach((items) =>
+      items.sort((a, b) => (a.subProcess ?? '').localeCompare(b.subProcess ?? ''))
+    );
+    return Array.from(groups.entries());
+  }, [coverage]);
+
+  const handleCreateInventory = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+    try {
+      await api.post(`/systems/inventory/${projectId}`, {
+        systemName: inventoryForm.systemName,
+        type: inventoryForm.type,
+        ownerArea: inventoryForm.ownerArea || undefined,
+        usersActive: inventoryForm.usersActive
+          ? Number(inventoryForm.usersActive)
+          : undefined,
+        criticality: inventoryForm.criticality || undefined,
+        notes: inventoryForm.notes || undefined,
+      });
+      setInventoryForm(defaultInventoryForm);
+      await loadInventory();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo crear el sistema'));
+    }
+  };
+
+  const handleUpdateInventory = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingInventory) return;
+    try {
+      await api.put(`/systems/inventory/${projectId}/${editingInventory.id}`, {
+        systemName: editingInventory.systemName,
+        type: editingInventory.type,
+        ownerArea: editingInventory.ownerArea || undefined,
+        usersActive: editingInventory.usersActive ?? undefined,
+        criticality: editingInventory.criticality || undefined,
+        notes: editingInventory.notes || undefined,
+      });
+      setEditingInventory(null);
+      await loadInventory();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo actualizar el sistema'));
+    }
+  };
+
+  const handleCreateCoverage = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+    try {
+      await api.post(`/systems/coverage/${projectId}`, {
+        process: coverageForm.process,
+        subProcess: coverageForm.subProcess || undefined,
+        systemNameRef: coverageForm.systemNameRef || undefined,
+        coverage: Number(coverageForm.coverage),
+        hasGap: coverageForm.hasGap === 'true',
+        gapDesc: coverageForm.gapDesc || undefined,
+        owner: coverageForm.owner || undefined,
+      });
+      setCoverageForm(defaultCoverageForm);
+      await loadCoverage();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo registrar la cobertura'));
+    }
+  };
+
+  const handleUpdateCoverage = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingCoverage) return;
+    try {
+      await api.put(`/systems/coverage/${projectId}/${editingCoverage.id}`, {
+        process: editingCoverage.process,
+        subProcess: editingCoverage.subProcess || undefined,
+        systemNameRef: editingCoverage.systemNameRef || undefined,
+        coverage: editingCoverage.coverage,
+        hasGap: editingCoverage.hasGap,
+        gapDesc: editingCoverage.gapDesc || undefined,
+        owner: editingCoverage.owner || undefined,
+      });
+      setEditingCoverage(null);
+      await loadCoverage();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo actualizar la cobertura'));
+    }
+  };
+
+  const handleCreateIntegration = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+    try {
+      await api.post(`/systems/integrations/${projectId}`, {
+        source: integrationForm.source,
+        target: integrationForm.target,
+        type: integrationForm.type,
+        periodicity: integrationForm.periodicity || undefined,
+        dailyVolume: integrationForm.dailyVolume
+          ? Number(integrationForm.dailyVolume)
+          : undefined,
+        format: integrationForm.format || undefined,
+        notes: integrationForm.notes || undefined,
+      });
+      setIntegrationForm(defaultIntegrationForm);
+      await loadIntegrations();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo crear la integración'));
+    }
+  };
+
+  const handleUpdateIntegration = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingIntegration) return;
+    try {
+      await api.put(`/systems/integrations/${projectId}/${editingIntegration.id}`, {
+        source: editingIntegration.source,
+        target: editingIntegration.target,
+        type: editingIntegration.type,
+        periodicity: editingIntegration.periodicity || undefined,
+        dailyVolume: editingIntegration.dailyVolume ?? undefined,
+        format: editingIntegration.format || undefined,
+        notes: editingIntegration.notes || undefined,
+      });
+      setEditingIntegration(null);
+      await loadIntegrations();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo actualizar la integración'));
+    }
+  };
+
+  const handleCreateDataQuality = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+    try {
+      await api.post(`/systems/data-quality/${projectId}`, {
+        systemName: dataQualityForm.systemName,
+        entity: dataQualityForm.entity,
+        hasCriticalFields: dataQualityForm.hasCriticalFields === 'true',
+        dataQuality: Number(dataQualityForm.dataQuality),
+        hasBusinessRules: dataQualityForm.hasBusinessRules === 'true',
+        historyYears: dataQualityForm.historyYears
+          ? Number(dataQualityForm.historyYears)
+          : undefined,
+        notes: dataQualityForm.notes || undefined,
+      });
+      setDataQualityForm(defaultDataQualityForm);
+      await loadDataQuality();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo registrar la calidad de datos'));
+    }
+  };
+
+  const handleUpdateDataQuality = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingDataQuality) return;
+    try {
+      await api.put(`/systems/data-quality/${projectId}/${editingDataQuality.id}`, {
+        systemName: editingDataQuality.systemName,
+        entity: editingDataQuality.entity,
+        hasCriticalFields: editingDataQuality.hasCriticalFields,
+        dataQuality: editingDataQuality.dataQuality,
+        hasBusinessRules: editingDataQuality.hasBusinessRules,
+        historyYears: editingDataQuality.historyYears ?? undefined,
+        notes: editingDataQuality.notes || undefined,
+      });
+      setEditingDataQuality(null);
+      await loadDataQuality();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo actualizar la calidad de datos'));
+    }
+  };
+
+  const removeInventory = async (id: string) => {
+    if (!isAdmin) return;
+    try {
+      await api.delete(`/systems/inventory/${projectId}/${id}`);
+      await loadInventory();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo eliminar el sistema'));
+    }
+  };
+
+  const removeCoverage = async (id: string) => {
+    if (!isAdmin) return;
+    try {
+      await api.delete(`/systems/coverage/${projectId}/${id}`);
+      await loadCoverage();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo eliminar la cobertura'));
+    }
+  };
+
+  const removeIntegration = async (id: string) => {
+    if (!isAdmin) return;
+    try {
+      await api.delete(`/systems/integrations/${projectId}/${id}`);
+      await loadIntegrations();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo eliminar la integración'));
+    }
+  };
+
+  const removeDataQuality = async (id: string) => {
+    if (!isAdmin) return;
+    try {
+      await api.delete(`/systems/data-quality/${projectId}/${id}`);
+      await loadDataQuality();
+    } catch (error: unknown) {
+      setError(getErrorMessage(error, 'No se pudo eliminar el registro de calidad'));
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Sistemas</h2>
+        <p className="text-sm text-slate-500">
+          Gestiona el inventario tecnológico, cobertura de procesos e integraciones clave del proyecto.
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>
+      )}
+
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900">Inventario de sistemas</h3>
+          <p className="text-sm text-slate-500">
+            Registra las plataformas relevantes, su criticidad y áreas responsables.
+          </p>
+        </header>
+        {canEdit && !editingInventory && (
+          <form
+            onSubmit={handleCreateInventory}
+            className="grid gap-3 rounded-lg border border-slate-200 p-4"
+          >
+            <h4 className="text-base font-medium text-slate-800">Nuevo sistema</h4>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Nombre del sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={inventoryForm.systemName}
+                  onChange={(event) =>
+                    setInventoryForm((prev) => ({
+                      ...prev,
+                      systemName: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Tipo / Categoría
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={inventoryForm.type}
+                  onChange={(event) =>
+                    setInventoryForm((prev) => ({
+                      ...prev,
+                      type: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Área responsable
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={inventoryForm.ownerArea}
+                  onChange={(event) =>
+                    setInventoryForm((prev) => ({
+                      ...prev,
+                      ownerArea: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Usuarios activos
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={inventoryForm.usersActive}
+                  onChange={(event) =>
+                    setInventoryForm((prev) => ({
+                      ...prev,
+                      usersActive: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Criticidad
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={inventoryForm.criticality}
+                  onChange={(event) =>
+                    setInventoryForm((prev) => ({
+                      ...prev,
+                      criticality: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={inventoryForm.notes}
+                  onChange={(event) =>
+                    setInventoryForm((prev) => ({
+                      ...prev,
+                      notes: event.target.value,
+                    }))
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Agregar sistema
+              </button>
+            </div>
+          </form>
+        )}
+
+        {editingInventory && canEdit && (
+          <form
+            onSubmit={handleUpdateInventory}
+            className="grid gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+          >
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-medium text-slate-800">Editar sistema</h4>
+              <button
+                type="button"
+                className="text-sm text-blue-700 underline"
+                onClick={() => setEditingInventory(null)}
+              >
+                Cancelar
+              </button>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Nombre del sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingInventory.systemName}
+                  onChange={(event) =>
+                    setEditingInventory((prev) =>
+                      prev ? { ...prev, systemName: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Tipo / Categoría
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingInventory.type}
+                  onChange={(event) =>
+                    setEditingInventory((prev) =>
+                      prev ? { ...prev, type: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Área responsable
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingInventory.ownerArea ?? ''}
+                  onChange={(event) =>
+                    setEditingInventory((prev) =>
+                      prev ? { ...prev, ownerArea: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Usuarios activos
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingInventory.usersActive ?? ''}
+                  onChange={(event) =>
+                    setEditingInventory((prev) =>
+                      prev
+                        ? { ...prev, usersActive: Number(event.target.value) }
+                        : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Criticidad
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingInventory.criticality ?? ''}
+                  onChange={(event) =>
+                    setEditingInventory((prev) =>
+                      prev ? { ...prev, criticality: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingInventory.notes ?? ''}
+                  onChange={(event) =>
+                    setEditingInventory((prev) =>
+                      prev ? { ...prev, notes: event.target.value } : prev
+                    )
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Actualizar sistema
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="space-y-2">
+          {inventory.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-wrap items-start justify-between gap-2 rounded border border-slate-200 bg-slate-50 p-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-slate-800">{item.systemName}</p>
+                <p className="text-xs text-slate-500">
+                  {item.type} · Área: {item.ownerArea ?? 'No definida'}
+                </p>
+                <p className="text-xs text-slate-500">
+                  Usuarios: {item.usersActive ?? 'N/D'} · Criticidad: {item.criticality ?? 'N/D'}
+                </p>
+                {item.notes && (
+                  <p className="text-xs text-slate-500">{item.notes}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {canEdit && (
+                  <button
+                    className="rounded bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                    onClick={() => setEditingInventory(item)}
+                  >
+                    Editar
+                  </button>
+                )}
+                {isAdmin && (
+                  <button
+                    className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white"
+                    onClick={() => removeInventory(item.id)}
+                  >
+                    Eliminar
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {inventory.length === 0 && (
+            <p className="text-sm text-slate-500">No hay sistemas registrados.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900">Cobertura de procesos</h3>
+          <p className="text-sm text-slate-500">
+            Analiza procesos, subprocesos y brechas identificadas en el inventario.
+          </p>
+        </header>
+        {canEdit && !editingCoverage && (
+          <form
+            onSubmit={handleCreateCoverage}
+            className="grid gap-3 rounded-lg border border-slate-200 p-4"
+          >
+            <h4 className="text-base font-medium text-slate-800">Nuevo registro</h4>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Proceso
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={coverageForm.process}
+                  onChange={(event) =>
+                    setCoverageForm((prev) => ({
+                      ...prev,
+                      process: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Subproceso
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={coverageForm.subProcess}
+                  onChange={(event) =>
+                    setCoverageForm((prev) => ({
+                      ...prev,
+                      subProcess: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Sistema asociado
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={coverageForm.systemNameRef}
+                  onChange={(event) =>
+                    setCoverageForm((prev) => ({
+                      ...prev,
+                      systemNameRef: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Cobertura (%)
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={coverageForm.coverage}
+                  onChange={(event) =>
+                    setCoverageForm((prev) => ({
+                      ...prev,
+                      coverage: Number(event.target.value),
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Brecha identificada
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={coverageForm.hasGap}
+                  onChange={(event) =>
+                    setCoverageForm((prev) => ({
+                      ...prev,
+                      hasGap: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="false">No</option>
+                  <option value="true">Sí</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Dueño
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={coverageForm.owner}
+                  onChange={(event) =>
+                    setCoverageForm((prev) => ({
+                      ...prev,
+                      owner: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Descripción de brecha / notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={coverageForm.gapDesc}
+                  onChange={(event) =>
+                    setCoverageForm((prev) => ({
+                      ...prev,
+                      gapDesc: event.target.value,
+                    }))
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Registrar cobertura
+              </button>
+            </div>
+          </form>
+        )}
+
+        {editingCoverage && canEdit && (
+          <form
+            onSubmit={handleUpdateCoverage}
+            className="grid gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+          >
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-medium text-slate-800">Editar registro</h4>
+              <button
+                type="button"
+                className="text-sm text-blue-700 underline"
+                onClick={() => setEditingCoverage(null)}
+              >
+                Cancelar
+              </button>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Proceso
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCoverage.process}
+                  onChange={(event) =>
+                    setEditingCoverage((prev) =>
+                      prev ? { ...prev, process: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Subproceso
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCoverage.subProcess ?? ''}
+                  onChange={(event) =>
+                    setEditingCoverage((prev) =>
+                      prev ? { ...prev, subProcess: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Sistema asociado
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCoverage.systemNameRef ?? ''}
+                  onChange={(event) =>
+                    setEditingCoverage((prev) =>
+                      prev ? { ...prev, systemNameRef: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Cobertura (%)
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCoverage.coverage}
+                  onChange={(event) =>
+                    setEditingCoverage((prev) =>
+                      prev ? { ...prev, coverage: Number(event.target.value) } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Brecha identificada
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCoverage.hasGap ? 'true' : 'false'}
+                  onChange={(event) =>
+                    setEditingCoverage((prev) =>
+                      prev ? { ...prev, hasGap: event.target.value === 'true' } : prev
+                    )
+                  }
+                >
+                  <option value="false">No</option>
+                  <option value="true">Sí</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Dueño
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCoverage.owner ?? ''}
+                  onChange={(event) =>
+                    setEditingCoverage((prev) =>
+                      prev ? { ...prev, owner: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Descripción de brecha / notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingCoverage.gapDesc ?? ''}
+                  onChange={(event) =>
+                    setEditingCoverage((prev) =>
+                      prev ? { ...prev, gapDesc: event.target.value } : prev
+                    )
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Actualizar registro
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="space-y-3">
+          {coverageGroups.map(([processName, items]) => (
+            <div key={processName} className="space-y-2 rounded border border-slate-200 bg-slate-50 p-3">
+              <div className="flex items-start justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-slate-800">{processName}</p>
+                  <p className="text-xs text-slate-500">
+                    Cobertura promedio:{' '}
+                    {Math.round(
+                      items.reduce((acc, item) => acc + item.coverage, 0) /
+                        (items.length || 1)
+                    )}
+                    %
+                  </p>
+                </div>
+              </div>
+              <ul className="space-y-2">
+                {items.map((item) => (
+                  <li
+                    key={item.id}
+                    className="flex flex-wrap items-center justify-between gap-2 rounded border border-slate-200 bg-white p-3"
+                  >
+                    <div>
+                      <p className="text-sm font-medium text-slate-800">
+                        {item.subProcess || 'Sin subproceso'}
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        Sistema: {item.systemNameRef || 'N/D'} · Cobertura: {item.coverage}%
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        Gap: {item.hasGap ? 'Sí' : 'No'} {item.gapDesc ? `· ${item.gapDesc}` : ''}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {canEdit && (
+                        <button
+                          className="rounded bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                          onClick={() => setEditingCoverage(item)}
+                        >
+                          Editar
+                        </button>
+                      )}
+                      {isAdmin && (
+                        <button
+                          className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white"
+                          onClick={() => removeCoverage(item.id)}
+                        >
+                          Eliminar
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+          {coverage.length === 0 && (
+            <p className="text-sm text-slate-500">Aún no se registran coberturas de procesos.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900">Integraciones</h3>
+          <p className="text-sm text-slate-500">
+            Documenta los flujos de información entre sistemas y su volumetría.
+          </p>
+        </header>
+        {canEdit && !editingIntegration && (
+          <form
+            onSubmit={handleCreateIntegration}
+            className="grid gap-3 rounded-lg border border-slate-200 p-4"
+          >
+            <h4 className="text-base font-medium text-slate-800">Nueva integración</h4>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Origen
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={integrationForm.source}
+                  onChange={(event) =>
+                    setIntegrationForm((prev) => ({
+                      ...prev,
+                      source: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Destino
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={integrationForm.target}
+                  onChange={(event) =>
+                    setIntegrationForm((prev) => ({
+                      ...prev,
+                      target: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Tipo
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={integrationForm.type}
+                  onChange={(event) =>
+                    setIntegrationForm((prev) => ({
+                      ...prev,
+                      type: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Periodicidad
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={integrationForm.periodicity}
+                  onChange={(event) =>
+                    setIntegrationForm((prev) => ({
+                      ...prev,
+                      periodicity: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Volumen diario
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={integrationForm.dailyVolume}
+                  onChange={(event) =>
+                    setIntegrationForm((prev) => ({
+                      ...prev,
+                      dailyVolume: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Formato
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={integrationForm.format}
+                  onChange={(event) =>
+                    setIntegrationForm((prev) => ({
+                      ...prev,
+                      format: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={integrationForm.notes}
+                  onChange={(event) =>
+                    setIntegrationForm((prev) => ({
+                      ...prev,
+                      notes: event.target.value,
+                    }))
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Registrar integración
+              </button>
+            </div>
+          </form>
+        )}
+
+        {editingIntegration && canEdit && (
+          <form
+            onSubmit={handleUpdateIntegration}
+            className="grid gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+          >
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-medium text-slate-800">Editar integración</h4>
+              <button
+                type="button"
+                className="text-sm text-blue-700 underline"
+                onClick={() => setEditingIntegration(null)}
+              >
+                Cancelar
+              </button>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Origen
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingIntegration.source}
+                  onChange={(event) =>
+                    setEditingIntegration((prev) =>
+                      prev ? { ...prev, source: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Destino
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingIntegration.target}
+                  onChange={(event) =>
+                    setEditingIntegration((prev) =>
+                      prev ? { ...prev, target: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Tipo
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingIntegration.type}
+                  onChange={(event) =>
+                    setEditingIntegration((prev) =>
+                      prev ? { ...prev, type: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Periodicidad
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingIntegration.periodicity ?? ''}
+                  onChange={(event) =>
+                    setEditingIntegration((prev) =>
+                      prev ? { ...prev, periodicity: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Volumen diario
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingIntegration.dailyVolume ?? ''}
+                  onChange={(event) =>
+                    setEditingIntegration((prev) =>
+                      prev ? { ...prev, dailyVolume: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Formato
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingIntegration.format ?? ''}
+                  onChange={(event) =>
+                    setEditingIntegration((prev) =>
+                      prev ? { ...prev, format: event.target.value } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingIntegration.notes ?? ''}
+                  onChange={(event) =>
+                    setEditingIntegration((prev) =>
+                      prev ? { ...prev, notes: event.target.value } : prev
+                    )
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Actualizar integración
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="space-y-2">
+          {integrations.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-wrap items-start justify-between gap-2 rounded border border-slate-200 bg-slate-50 p-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-slate-800">
+                  {item.source} → {item.target}
+                </p>
+                <p className="text-xs text-slate-500">
+                  Tipo: {item.type} · Periodicidad: {item.periodicity || 'N/D'}
+                </p>
+                <p className="text-xs text-slate-500">
+                  Volumen: {item.dailyVolume ?? 'N/D'} · Formato: {item.format ?? 'N/D'}
+                </p>
+                {item.notes && (
+                  <p className="text-xs text-slate-500">{item.notes}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {canEdit && (
+                  <button
+                    className="rounded bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                    onClick={() => setEditingIntegration(item)}
+                  >
+                    Editar
+                  </button>
+                )}
+                {isAdmin && (
+                  <button
+                    className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white"
+                    onClick={() => removeIntegration(item.id)}
+                  >
+                    Eliminar
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {integrations.length === 0 && (
+            <p className="text-sm text-slate-500">No hay integraciones registradas.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900">Calidad de datos</h3>
+          <p className="text-sm text-slate-500">
+            Evalúa atributos de calidad y gobernanza sobre las entidades relevantes.
+          </p>
+        </header>
+        {canEdit && !editingDataQuality && (
+          <form
+            onSubmit={handleCreateDataQuality}
+            className="grid gap-3 rounded-lg border border-slate-200 p-4"
+          >
+            <h4 className="text-base font-medium text-slate-800">Nuevo registro</h4>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={dataQualityForm.systemName}
+                  onChange={(event) =>
+                    setDataQualityForm((prev) => ({
+                      ...prev,
+                      systemName: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Entidad / tabla
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={dataQualityForm.entity}
+                  onChange={(event) =>
+                    setDataQualityForm((prev) => ({
+                      ...prev,
+                      entity: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Campos críticos
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={dataQualityForm.hasCriticalFields}
+                  onChange={(event) =>
+                    setDataQualityForm((prev) => ({
+                      ...prev,
+                      hasCriticalFields: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Calidad (0-100)
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={dataQualityForm.dataQuality}
+                  onChange={(event) =>
+                    setDataQualityForm((prev) => ({
+                      ...prev,
+                      dataQuality: Number(event.target.value),
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Reglas de negocio
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={dataQualityForm.hasBusinessRules}
+                  onChange={(event) =>
+                    setDataQualityForm((prev) => ({
+                      ...prev,
+                      hasBusinessRules: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Años de historia
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={dataQualityForm.historyYears}
+                  onChange={(event) =>
+                    setDataQualityForm((prev) => ({
+                      ...prev,
+                      historyYears: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={dataQualityForm.notes}
+                  onChange={(event) =>
+                    setDataQualityForm((prev) => ({
+                      ...prev,
+                      notes: event.target.value,
+                    }))
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Registrar calidad
+              </button>
+            </div>
+          </form>
+        )}
+
+        {editingDataQuality && canEdit && (
+          <form
+            onSubmit={handleUpdateDataQuality}
+            className="grid gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+          >
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-medium text-slate-800">Editar registro</h4>
+              <button
+                type="button"
+                className="text-sm text-blue-700 underline"
+                onClick={() => setEditingDataQuality(null)}
+              >
+                Cancelar
+              </button>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                Sistema
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingDataQuality.systemName}
+                  onChange={(event) =>
+                    setEditingDataQuality((prev) =>
+                      prev ? { ...prev, systemName: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Entidad / tabla
+                <input
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingDataQuality.entity}
+                  onChange={(event) =>
+                    setEditingDataQuality((prev) =>
+                      prev ? { ...prev, entity: event.target.value } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Campos críticos
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingDataQuality.hasCriticalFields ? 'true' : 'false'}
+                  onChange={(event) =>
+                    setEditingDataQuality((prev) =>
+                      prev
+                        ? { ...prev, hasCriticalFields: event.target.value === 'true' }
+                        : prev
+                    )
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Calidad (0-100)
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingDataQuality.dataQuality}
+                  onChange={(event) =>
+                    setEditingDataQuality((prev) =>
+                      prev ? { ...prev, dataQuality: Number(event.target.value) } : prev
+                    )
+                  }
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                Reglas de negocio
+                <select
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingDataQuality.hasBusinessRules ? 'true' : 'false'}
+                  onChange={(event) =>
+                    setEditingDataQuality((prev) =>
+                      prev
+                        ? { ...prev, hasBusinessRules: event.target.value === 'true' }
+                        : prev
+                    )
+                  }
+                >
+                  <option value="true">Sí</option>
+                  <option value="false">No</option>
+                </select>
+              </label>
+              <label className="flex flex-col text-sm">
+                Años de historia
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingDataQuality.historyYears ?? ''}
+                  onChange={(event) =>
+                    setEditingDataQuality((prev) =>
+                      prev ? { ...prev, historyYears: Number(event.target.value) } : prev
+                    )
+                  }
+                />
+              </label>
+              <label className="flex flex-col text-sm md:col-span-2">
+                Notas
+                <textarea
+                  className="mt-1 rounded border px-3 py-2"
+                  value={editingDataQuality.notes ?? ''}
+                  onChange={(event) =>
+                    setEditingDataQuality((prev) =>
+                      prev ? { ...prev, notes: event.target.value } : prev
+                    )
+                  }
+                  rows={2}
+                />
+              </label>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+              >
+                Actualizar calidad
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="space-y-2">
+          {dataQuality.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-wrap items-start justify-between gap-2 rounded border border-slate-200 bg-slate-50 p-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-slate-800">
+                  {item.systemName} · {item.entity}
+                </p>
+                <p className="text-xs text-slate-500">
+                  Calidad: {item.dataQuality}% · Campos críticos: {item.hasCriticalFields ? 'Sí' : 'No'}
+                </p>
+                <p className="text-xs text-slate-500">
+                  Reglas de negocio: {item.hasBusinessRules ? 'Sí' : 'No'} · Historia: {item.historyYears ?? 'N/D'} años
+                </p>
+                {item.notes && (
+                  <p className="text-xs text-slate-500">{item.notes}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {canEdit && (
+                  <button
+                    className="rounded bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                    onClick={() => setEditingDataQuality(item)}
+                  >
+                    Editar
+                  </button>
+                )}
+                {isAdmin && (
+                  <button
+                    className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white"
+                    onClick={() => removeDataQuality(item.id)}
+                  >
+                    Eliminar
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {dataQuality.length === 0 && (
+            <p className="text-sm text-slate-500">No hay registros de calidad de datos.</p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/pages/AdminDashboard.tsx
+++ b/web/src/pages/AdminDashboard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import CompanyManager from '../features/admin/CompanyManager';
+import DataRequestCategoryManager from '../features/admin/DataRequestCategoryManager';
 import UserManager from '../features/admin/UserManager';
 import { useAuth } from '../hooks/useAuth';
 import api from '../lib/api';
@@ -194,9 +195,10 @@ export default function AdminDashboard() {
         </article>
       </section>
 
-      <div className="grid gap-8 lg:grid-cols-2">
+      <div className="grid gap-8 lg:grid-cols-3">
         <CompanyManager onChange={refreshSummary} />
         <UserManager onChange={refreshSummary} />
+        <DataRequestCategoryManager onChange={refreshSummary} />
       </div>
     </div>
   );

--- a/web/src/pages/ProjectPage.tsx
+++ b/web/src/pages/ProjectPage.tsx
@@ -16,7 +16,9 @@ interface ProjectSummary {
 }
 
 const TAB_TO_PATH: Record<string, string> = {
-  prekickoff: '',
+  summary: '',
+  prekickoff: 'prekickoff',
+  plan: 'plan',
   surveys: 'surveys',
   interviews: 'interviews',
   processes: 'procesos',
@@ -151,7 +153,7 @@ export const ProjectPage = () => {
   const segments = location.pathname.split('/').filter(Boolean);
   const subSegments = segments.slice(2);
   const pathKey = subSegments[0] ?? '';
-  const activeTab = PATH_TO_TAB[pathKey || '__root__'] ?? 'prekickoff';
+  const activeTab = PATH_TO_TAB[pathKey || '__root__'] ?? 'summary';
 
   const canCreateProject = role === 'admin' || role === 'consultor';
 


### PR DESCRIPTION
## Summary
- add admin endpoints and UI for managing pre-kickoff data request categories
- introduce project plan APIs and Gantt editor tab for managing project tasks
- provide project summary API/tab, enhanced systems & security management, and richer survey analytics
- refresh executive PDF export layout to highlight key metrics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d86af0e3388331898670326878ed24