### PR TITLE
Add helper to render export project tab section

### DIFF
--- a/web/src/features/projects/ProjectTabs.tsx
+++ b/web/src/features/projects/ProjectTabs.tsx
@@ -18,6 +18,17 @@ interface TabComponentProps {
   projectId: string;
 }
 
+const makeSection = (title: string, description: string): FC<TabComponentProps> => {
+  const Section: FC<TabComponentProps> = () => (
+    <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 className="text-xl font-semibold text-slate-900">{title}</h2>
+      <p className="text-sm text-slate-500">{description}</p>
+    </div>
+  );
+
+  return Section;
+};
+
 export const ProjectTabs: {
   value: string;
   label: string;


### PR DESCRIPTION
## Summary
- add a reusable helper that generates static section tabs with consistent styling
- render the Exportar tab using the new helper so it displays a styled heading and description

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d996cd73f88331b59b4b50120489d3