### PR TITLE
Add project task and data category migration

### DIFF
--- a/api/prisma/migrations/20250928020000_add_project_task_and_data_category/migration.sql
+++ b/api/prisma/migrations/20250928020000_add_project_task_and_data_category/migration.sql
@@ -1,0 +1,45 @@
+-- CreateTable
+CREATE TABLE "DataRequestCategory" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DataRequestCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProjectTask" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "parentId" TEXT,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "owner" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'Planificado',
+    "progress" INTEGER,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "sortOrder" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProjectTask_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DataRequestCategory_name_key" ON "DataRequestCategory"("name");
+
+-- CreateIndex
+CREATE INDEX "ProjectTask_projectId_idx" ON "ProjectTask"("projectId");
+
+-- CreateIndex
+CREATE INDEX "ProjectTask_parentId_idx" ON "ProjectTask"("parentId");
+
+-- AddForeignKey
+ALTER TABLE "ProjectTask" ADD CONSTRAINT "ProjectTask_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectTask" ADD CONSTRAINT "ProjectTask_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "ProjectTask"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/api/prisma/seed.js
+++ b/api/prisma/seed.js
@@ -28,7 +28,7 @@ async function main() {
   const consultor = await upsertUser('consultor@demo.com', 'Consultor', 'consultor', 'Cambiar123!');
   const cliente = await upsertUser('cliente@demo.com', 'Cliente', 'cliente', 'Cambiar123!');
 
-  await prisma.project.upsert({
+  const nutrialProject = await prisma.project.upsert({
     where: {
       Project_companyId_name_key: {
         companyId: nutrial.id,
@@ -52,9 +52,89 @@ async function main() {
     },
   });
 
+  const categories = [
+    { name: 'Finanzas', description: 'Estados financieros, presupuestos y proyecciones.' },
+    { name: 'Operaciones', description: 'Procesos operativos, indicadores y documentación de control.' },
+    { name: 'Tecnología', description: 'Inventario de sistemas, integraciones y seguridad.' },
+  ];
+
+  for (const category of categories) {
+    await prisma.dataRequestCategory.upsert({
+      where: { name: category.name },
+      update: { description: category.description },
+      create: category,
+    });
+  }
+
+  const planningTaskId = 'seed-task-planning';
+  const assessmentTaskId = 'seed-task-assessment';
+
+  const planningTaskStart = new Date('2025-01-06T00:00:00.000Z');
+  const planningTaskEnd = new Date('2025-01-17T00:00:00.000Z');
+  const assessmentTaskStart = new Date('2025-01-20T00:00:00.000Z');
+  const assessmentTaskEnd = new Date('2025-02-07T00:00:00.000Z');
+
+  await prisma.projectTask.upsert({
+    where: { id: planningTaskId },
+    update: {
+      name: 'Planificación de auditoría',
+      description: 'Definir alcance, recursos y cronograma del proyecto.',
+      owner: 'Admin',
+      status: 'En progreso',
+      progress: 60,
+      startDate: planningTaskStart,
+      endDate: planningTaskEnd,
+      sortOrder: 1,
+      projectId: nutrialProject.id,
+    },
+    create: {
+      id: planningTaskId,
+      projectId: nutrialProject.id,
+      name: 'Planificación de auditoría',
+      description: 'Definir alcance, recursos y cronograma del proyecto.',
+      owner: 'Admin',
+      status: 'En progreso',
+      progress: 60,
+      startDate: planningTaskStart,
+      endDate: planningTaskEnd,
+      sortOrder: 1,
+    },
+  });
+
+  await prisma.projectTask.upsert({
+    where: { id: assessmentTaskId },
+    update: {
+      name: 'Levantamiento y evaluación',
+      description: 'Entrevistas, levantamiento documental y evaluación preliminar.',
+      owner: 'Consultor',
+      status: 'Planificado',
+      progress: 0,
+      startDate: assessmentTaskStart,
+      endDate: assessmentTaskEnd,
+      sortOrder: 2,
+      parentId: planningTaskId,
+      projectId: nutrialProject.id,
+    },
+    create: {
+      id: assessmentTaskId,
+      projectId: nutrialProject.id,
+      parentId: planningTaskId,
+      name: 'Levantamiento y evaluación',
+      description: 'Entrevistas, levantamiento documental y evaluación preliminar.',
+      owner: 'Consultor',
+      status: 'Planificado',
+      progress: 0,
+      startDate: assessmentTaskStart,
+      endDate: assessmentTaskEnd,
+      sortOrder: 2,
+    },
+  });
+
   console.log('Seed OK', {
     companies: [nutrial.name, democorp.name],
     users: ['admin@demo.com', 'consultor@demo.com', 'cliente@demo.com'],
+    dataRequestCategories: categories.map((category) => category.name),
+    projectTasks: [planningTaskId, assessmentTaskId],
   });
 }
 


### PR DESCRIPTION
## Summary
- add a Prisma migration that creates the DataRequestCategory and ProjectTask tables with their indexes and relations
- extend the seed script to populate default data request categories and example project tasks

## Testing
- docker compose exec api npm run migrate:deploy *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d999b3d1748331af43f2afad5d77d1