### PR TITLE
chore: harden docker compose environment bootstrap

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,13 @@
+# Docker Compose development defaults
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=auditoria
+POSTGRES_PORT=5432
+DATABASE_URL=postgresql://postgres:postgres@db:5432/auditoria?schema=public
+API_PORT=4000
+WEB_PORT=5173
+JWT_SECRET=dev-jwt-secret
+JWT_REFRESH_SECRET=dev-jwt-refresh-secret
+CLIENT_URL=http://localhost:5173
+FILE_STORAGE_PATH=/usr/src/app/storage
+VITE_API_URL=http://localhost:4000/api

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,13 @@
+# Example production configuration - replace values appropriately
+POSTGRES_USER=change-me
+POSTGRES_PASSWORD=change-me
+POSTGRES_DB=auditoria
+POSTGRES_PORT=5432
+DATABASE_URL=postgresql://change-me:change-me@db:5432/auditoria?schema=public
+API_PORT=4000
+WEB_PORT=5173
+JWT_SECRET=replace-with-strong-secret
+JWT_REFRESH_SECRET=replace-with-strong-refresh-secret
+CLIENT_URL=https://your-frontend.example.com
+FILE_STORAGE_PATH=/usr/src/app/storage
+VITE_API_URL=https://your-api.example.com/api

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ web/dist
 *.env
 *.env.*
 .env.example
+!.env.development
+!.env.production

--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ Suite full-stack para gestionar auditorías multi-proyecto con módulos especial
 4. [Docker](#docker)
 5. [Semilla de datos (Dev)](#semilla-de-datos-dev)
 6. [Variables de entorno](#variables-de-entorno)
-7. [Usuarios demo](#usuarios-demo)
-8. [Módulos clave](#módulos-clave)
-9. [Scripts útiles](#scripts-útiles)
-10. [OpenAPI](#openapi)
-11. [Tests](#tests)
-12. [Seeds](#seeds)
-13. [Capturas](#capturas)
+7. [Módulos clave](#módulos-clave)
+8. [Scripts útiles](#scripts-útiles)
+9. [OpenAPI](#openapi)
+10. [Tests](#tests)
+11. [Seeds](#seeds)
+12. [Capturas](#capturas)
 
 ## Arquitectura
 
@@ -37,10 +36,12 @@ Suite full-stack para gestionar auditorías multi-proyecto con módulos especial
 ## Configuración local
 
 ```bash
-docker compose up -d --build
-docker compose exec api npm run migrate:deploy
+docker compose --env-file .env.development up -d --build
+# Opcional (solo en entornos de desarrollo):
 docker compose exec api npm run seed
 ```
+
+La API espera a que la base de datos esté disponible y aplica automáticamente `prisma migrate deploy` en cada arranque del contenedor.
 
 Una vez que la base de datos está lista, puedes iniciar los servicios de desarrollo individuales si prefieres trabajar fuera de Docker:
 
@@ -69,33 +70,26 @@ curl http://localhost:4000/api/health
 ## Docker
 
 ```bash
-docker compose up -d --build
+docker compose --env-file .env.development up -d --build
 ```
 
 ## Semilla de datos (Dev)
 
-1. Levanta servicios:
+1. Levanta servicios (usa el archivo `.env.development` o el que definas):
    ```bash
-   docker compose up -d --build
+   docker compose --env-file .env.development up -d --build
    ```
-2. Aplica migraciones:
-   ```bash
-   docker compose exec api npm run migrate:deploy
-   ```
-3. Ejecuta seed:
+2. Ejecuta seed:
    ```bash
    docker compose exec api npm run seed
    ```
 
-Usuarios por defecto:
-
-admin@demo.com / Cambiar123!
-consultor@demo.com / Cambiar123!
-cliente@demo.com / Cambiar123!
+Las credenciales que genera el seed están pensadas solo para entornos locales y pueden revisarse en `prisma/seed.ts`. Ajusta o
+reemplaza esos datos antes de compartir entornos compartidos.
 
 ## Variables de entorno
 
-Cada paquete incluye un archivo `.env.example` con los valores mínimos para iniciar el proyecto. Los más relevantes son:
+El repositorio incluye `.env.development` y `.env.production` como punto de partida para ejecutar `docker compose --env-file`. Personaliza los valores antes de desplegar en cualquier entorno real. Además, cada paquete mantiene su propio `.env.example` con los mínimos para entornos fuera de Docker. Los valores más relevantes son:
 
 | Variable | Descripción | Paquete |
 | --- | --- | --- |
@@ -103,15 +97,7 @@ Cada paquete incluye un archivo `.env.example` con los valores mínimos para ini
 | `JWT_SECRET` | Clave de firma para los tokens JWT. | `api` |
 | `VITE_API_URL` | URL base de la API consumida por el front-end. | `web` |
 
-Recuerda copiar cada archivo `*.env.example` a `.env` y personalizarlo según tu entorno antes de iniciar los servicios.
-
-## Usuarios demo
-
-| Email | Rol | Contraseña |
-| --- | --- | --- |
-| admin@demo.com | Admin | Cambiar123! |
-| consultor@demo.com | Consultor | Cambiar123! |
-| cliente@demo.com | Cliente | Cambiar123! |
+Cuando trabajes fuera de Docker, copia cada archivo `*.env.example` a `.env` y personalízalo según tu entorno antes de iniciar los servicios.
 
 ## Módulos clave
 
@@ -183,7 +169,7 @@ npm run test
 El seed `npm run seed` (o `docker compose exec api npm run seed`) crea:
 
 - Empresas demo **Nutrial** y **DemoCorp**.
-- Usuarios `admin@demo.com`, `consultor@demo.com` y `cliente@demo.com` con contraseña `Cambiar123!`.
+- Usuarios demo de ejemplo (consulta `prisma/seed.ts` para los detalles y reemplaza las credenciales en tus propios entornos).
 - Proyecto **Nutrial – Auditoría 2025** con `settings.enabledFeatures = ['reception', 'picking', 'dispatch']` y memberships según roles.
 
 ## Capturas

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -18,7 +18,6 @@ WORKDIR /usr/src/app
 COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY . .
 RUN npm run build
-RUN npm prune --production
 
 # --- runner ---
 FROM node:18-bullseye-slim AS runner
@@ -29,6 +28,8 @@ COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
 COPY prisma ./prisma
 COPY package*.json ./
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
 EXPOSE 4000
-CMD ["node", "dist/server.cjs"]
+CMD ["./docker-entrypoint.sh"]
 

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL is not set" >&2
+  exit 1
+fi
+
+printf 'Applying database migrations...\n'
+until npx prisma migrate deploy >/tmp/prisma-migrate.log 2>&1; do
+  cat /tmp/prisma-migrate.log >&2 || true
+  printf 'Database unavailable, retrying in 5 seconds...\n'
+  sleep 5
+  printf 'Re-attempting database migrations...\n'
+  rm -f /tmp/prisma-migrate.log
+done
+cat /tmp/prisma-migrate.log >&2 || true
+rm -f /tmp/prisma-migrate.log
+printf 'Database migrations applied successfully.\n'
+
+exec node dist/server.cjs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,61 @@
-version: '3.9'
 services:
   db:
     image: postgres:15
+    container_name: auditoria-db
+    restart: unless-stopped
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: auditoria
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
-      - '5432:5432'
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
   api:
-    build: ./api
-    command: npm run start
+    build:
+      context: ./api
+    container_name: auditoria-api
+    restart: unless-stopped
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@db:5432/auditoria
-      JWT_SECRET: super-secret
-      JWT_REFRESH_SECRET: super-refresh
-      PORT: 4000
-      FILE_STORAGE_PATH: /usr/src/app/storage
-      CLIENT_URL: http://localhost:5173
+      NODE_ENV: ${NODE_ENV:-development}
+      DATABASE_URL: ${DATABASE_URL}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
+      PORT: ${API_PORT:-4000}
+      FILE_STORAGE_PATH: ${FILE_STORAGE_PATH:-/usr/src/app/storage}
+      CLIENT_URL: ${CLIENT_URL}
     depends_on:
       - db
     ports:
-      - '4000:4000'
+      - "${API_PORT:-4000}:4000"
     volumes:
       - api-storage:/usr/src/app/storage
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:${API_PORT:-4000}/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
   web:
-    build: ./web
-    ports:
-      - '5173:5173'
+    build:
+      context: ./web
+    container_name: auditoria-web
+    restart: unless-stopped
     environment:
-      VITE_API_URL: http://localhost:4000/api
+      VITE_API_URL: ${VITE_API_URL:-http://localhost:4000/api}
     depends_on:
       - api
+    ports:
+      - "${WEB_PORT:-5173}:5173"
+
 volumes:
   postgres-data:
   api-storage:


### PR DESCRIPTION
## Summary
- refresh docker-compose to rely on environment files, add healthchecks, and expose configurable ports
- add an API entrypoint that waits for Postgres and applies Prisma migrations before starting
- document the new workflow and provide development/production env templates without exposing demo credentials

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9a14f81dc8331b19dc528694b63b3