### PR TITLE
feat(web): migrate to @formio/react

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,15 +8,14 @@
       "name": "auditoria-web",
       "version": "2.0.0",
       "dependencies": {
+        "@formio/react": "5.3.0",
         "@radix-ui/react-tabs": "^1.0.3",
         "@tanstack/react-query": "^5.24.0",
         "axios": "^1.12.2",
         "bpmn-js": "^17.11.1",
-        "formiojs": "^4.21.7",
         "lucide-react": "^0.298.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-formio": "^4.3.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
@@ -958,6 +957,7 @@
       "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.4-rc.1.tgz",
       "integrity": "sha512-4B5rs+w9tAk5i+wbdw2/NrTxPqnDX7/W19tiTd9lfXnIGQmaj0ecMEVqDmOJg8pIlyU02g3c4ih6JnA/JVmUbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "resize-observer-polyfill": "^1.5.1"
       }
@@ -967,29 +967,57 @@
       "resolved": "https://registry.npmjs.org/@formio/choices.js/-/choices.js-10.2.1.tgz",
       "integrity": "sha512-NCE5u7jG3XGokJP16MyAbVSUptKu/mpJYAxd4PPIoLiO/l9Do5uoOQ0MgNb9qG9qABJiOX+qNRE8q8RybY/SwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.2.2",
         "fuse.js": "^6.6.2",
         "redux": "^4.2.0"
       }
     },
+    "node_modules/@formio/react": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@formio/react/-/react-5.3.0.tgz",
+      "integrity": "sha512-C5TGhvMb7qD18gINvktG1STkbaDIW0/uqgti216sJCziIX8w5K+RzATrVtxUAQrGxtPF90gxYLglQGYmKhZjnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-polyfill": "^6.26.0",
+        "core-js": "^3.32.0",
+        "eventemitter2": "^6.4.5",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "formiojs": "^4.15.1",
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.1.0",
+        "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.1.0"
+      }
+    },
+    "node_modules/@formio/react/node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
+    },
     "node_modules/@formio/semantic": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.6.1.tgz",
       "integrity": "sha512-obp1BT5UnzD+uYBbqmnsTfO2hGxI2A2iR/cj3P5JUFLYSBpnr3TS2ShQ7Ee5GCRRtJPu0JnljuJj+YSKLCMuhg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@formio/text-mask-addons": {
       "version": "3.8.0-formio.4",
       "resolved": "https://registry.npmjs.org/@formio/text-mask-addons/-/text-mask-addons-3.8.0-formio.4.tgz",
       "integrity": "sha512-vhkeIyuL+1rtC9S4IW8O3JCwroPtvJrkrcMO4wyELNqMIgQRKbiyBAitZfUP4tY04xdB5lxAinbzdwb+NMdX6w==",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/@formio/vanilla-text-mask": {
       "version": "5.1.1-formio.1",
       "resolved": "https://registry.npmjs.org/@formio/vanilla-text-mask/-/vanilla-text-mask-5.1.1-formio.1.tgz",
       "integrity": "sha512-rYBlvIPMNUd6sAaduOaiIwI4vfTAjHDRonko2qJn2RP1O//TQ7rcFIPYVYePJZ4OtOpwHiHAvAIh79McphZotQ==",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -1193,6 +1221,7 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1814,7 +1843,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.2.tgz",
       "integrity": "sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.2",
@@ -1980,14 +2010,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1998,7 +2028,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -2009,7 +2039,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -2388,7 +2419,8 @@
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
       "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -2444,7 +2476,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/animation-frame-polyfill/-/animation-frame-polyfill-1.0.2.tgz",
       "integrity": "sha512-PvO5poSMoHhaoNNgHPo+oqs/0L9UqjsUbqv0iOXVqLh6HX85fsOVQTUrzSBvjdZz7hydARlgLELyzJJKIrPJAQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -2538,7 +2571,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -2701,13 +2735,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
       "integrity": "sha512-VVE1H6cc4ai+ZXo/CRWoJiHXrA1qfA31DPnx6D20+kSI547hQN5Greh51LQ1baMRMfxO5K5M4ImMtZbZt2DODQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/autocompleter": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-7.1.0.tgz",
       "integrity": "sha512-uCToOnq7eAD/GJAteDbYuQ7ksDtrYWOy5CIAq43wh0dT+5frMpPlyD9tp+y5fz8KIcsP+zR2MjzoTAdW5aJESw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -2905,13 +2941,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browser-cookies/-/browser-cookies-1.2.0.tgz",
       "integrity": "sha512-cg2WuoOJo+F+g2XjEaP8nmeRp1vDHjt7sqpKJMsTNXKrpyIBNVslYJeehvs6FEddj8usV2+qyRSBEX244yN5/g==",
-      "license": "Unlicence"
+      "license": "Unlicence",
+      "peer": true
     },
     "node_modules/browser-md5-file": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/browser-md5-file/-/browser-md5-file-1.1.1.tgz",
       "integrity": "sha512-9h2UViTtZPhBa7oHvp5mb7MvJaX5OKEPUsplDwJ800OIV+In7BOR3RXOMB78obn2iQVIiS3WkVLhG7Zu1EMwbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spark-md5": "^2.0.2"
       }
@@ -3187,7 +3225,8 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
       "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/component-event": {
       "version": "0.2.1",
@@ -3207,6 +3246,7 @@
       "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.4.tgz",
       "integrity": "sha512-N9ArHAqwR/lhPq4OdIAwH4e1btn6EIZMAz4TazjnzCiVECcWUPTma+dRAM38ERImEJBh8NiCCpjoQruSZ+agYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "atoa": "1.0.0",
         "ticky": "1.0.1"
@@ -3235,6 +3275,7 @@
       "resolved": "https://registry.npmjs.org/create-point-cb/-/create-point-cb-1.2.0.tgz",
       "integrity": "sha512-r4l6IO/YGI7hIZRMLggOzwM6XO80+Fdcv4hx1fXCEdU+hKd7zZki6i+cbYfK9OliMwMYx1wPfQLU/snvS+Dygw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-func": "^1.0.1"
       }
@@ -3259,6 +3300,7 @@
       "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.5.tgz",
       "integrity": "sha512-MY4xhBYEnVi+pmTpHCOCsCLYczc0PVtGdPBz6NXNXxikLaUZo4HdAeUb1UqAo3t3yXAloSelTmfxJ+/oUqkW5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "custom-event": "^1.0.0"
       }
@@ -3308,20 +3350,22 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/custom-event-polyfill": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
       "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3438,6 +3482,7 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3537,7 +3582,8 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
       "integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w==",
-      "license": "BSD"
+      "license": "BSD",
+      "peer": true
     },
     "node_modules/didi": {
       "version": "10.2.2",
@@ -3600,6 +3646,7 @@
       "resolved": "https://registry.npmjs.org/dom-autoscroller/-/dom-autoscroller-2.3.4.tgz",
       "integrity": "sha512-HcAdt/2Dq9x4CG6LWXc2x9Iq0MJPAu8fuzHncclq7byufqYEYVtx9sZ/dyzR+gdj4qwEC9p27Lw1G2HRRYX6jQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "animation-frame-polyfill": "^1.0.0",
         "create-point-cb": "^1.0.0",
@@ -3613,13 +3660,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dom-mousemove-dispatcher/-/dom-mousemove-dispatcher-1.0.1.tgz",
       "integrity": "sha512-NMdqqMbgW8kqOdmod2hkS+9hD/v7h4XoSvwU9qqe+wAA/O+ba0jhpbfW0Kb/fCyR0RX9jf4dwfQrl04LQX4FzQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-plane": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/dom-plane/-/dom-plane-1.0.2.tgz",
       "integrity": "sha512-/tR67G6ZGSciXoZLsD706yLxEXvX3mG/OWE8YNYj3A1yU/RAimtPXzklVTu5Y5xoeMoloA/Y+MaNjQm9apgAww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "create-point-cb": "^1.0.0"
       }
@@ -3629,6 +3678,7 @@
       "resolved": "https://registry.npmjs.org/dom-set/-/dom-set-1.1.1.tgz",
       "integrity": "sha512-sUi2aSvRsK3Ixx++gwX9cnaWk9ZxGVFry8+HnTRVmDimybU5PaiI4wX0o00mVtjFKlQNZLmtGoPTLorYbN0+Rw==",
       "license": "WTFPL",
+      "peer": true,
       "dependencies": {
         "array-from": "^2.1.1",
         "is-array": "^1.0.1",
@@ -3649,6 +3699,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -3657,13 +3708,15 @@
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
       "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dragula": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/dragula/-/dragula-3.7.3.tgz",
       "integrity": "sha512-/rRg4zRhcpf81TyDhaHLtXt6sEywdfpv1cRUMeFFy7DuypH2U0WUL0GTdyAQvXegviT4PJK4KuMmOaIDpICseQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "contra": "1.9.4",
         "crossvent": "1.5.5"
@@ -4223,17 +4276,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter2": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
-      "integrity": "sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg==",
-      "license": "MIT"
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
@@ -4291,7 +4339,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
       "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -4322,6 +4371,7 @@
       "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz",
       "integrity": "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-fetch": "~2.6.1"
       }
@@ -4465,6 +4515,7 @@
       "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.21.7.tgz",
       "integrity": "sha512-DDXPhXABxdEbpyfv0C8SAS6zt92luGFXqe0usPHxSHvlP960GQkhS//WV7TAMrRsjj1WTIqqv3XZha8qTknG3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formio/bootstrap3": "2.12.4-rc.1",
         "@formio/choices.js": "10.2.1",
@@ -4587,6 +4638,7 @@
       "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
       "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4921,6 +4973,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.6"
       }
@@ -4942,7 +4995,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ids": {
       "version": "1.0.5",
@@ -5026,7 +5080,8 @@
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9.tgz",
       "integrity": "sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5047,7 +5102,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
       "integrity": "sha512-gxiZ+y/u67AzpeFmAmo4CbtME/bs7J2C++su5zQzvQyaxUqVzkh69DI+jN+KZuSO6JaH6TIIU6M6LhqxMjxEpw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -5491,7 +5547,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/iselement/-/iselement-1.1.4.tgz",
       "integrity": "sha512-4Q519eWmbHO1pbimiz7H1iJRUHVmAmfh0viSsUD+oAwVO4ntZt7gpf8i8AShVBTyOvRTZNYNBpUxOIvwZR+ffw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5504,7 +5561,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
       "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -5634,7 +5692,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz",
       "integrity": "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5666,7 +5725,8 @@
     "node_modules/jstimezonedetect": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/jstimezonedetect/-/jstimezonedetect-1.0.7.tgz",
-      "integrity": "sha512-ARADHortktl9IZ1tr4GHwGPIAzgz3mLNCbR/YjWtRtc/O0o634O3NeFlpLjv95EvuDA5dc8z6yfgbS8nUc4zcQ=="
+      "integrity": "sha512-ARADHortktl9IZ1tr4GHwGPIAzgz3mLNCbR/YjWtRtc/O0o634O3NeFlpLjv95EvuDA5dc8z6yfgbS8nUc4zcQ==",
+      "peer": true
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -5688,7 +5748,8 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
       "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5760,20 +5821,23 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5969,6 +6033,7 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -5978,6 +6043,7 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
       "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -6027,7 +6093,8 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6041,6 +6108,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6060,19 +6128,22 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6327,7 +6398,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
       "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -6699,6 +6771,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -6820,6 +6909,7 @@
       "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
       "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "lodash-es": "^4.17.21",
@@ -6835,6 +6925,7 @@
       "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
       "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-diff": "^1.3.0",
         "lodash.clonedeep": "^4.5.0",
@@ -6848,7 +6939,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -6873,24 +6965,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-formio": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/react-formio/-/react-formio-4.3.0.tgz",
-      "integrity": "sha512-oCWR449XIxJeShxbbSCwAOOv3CmPehLvRPSyuPAVHYhHoRzkE5m/cdC7f36EDo4dHorlVcq3zt/m4F/6TKLLiA==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-polyfill": "^6.26.0",
-        "core-js": "^3.1.4",
-        "eventemitter2": "^5.0.1",
-        "formiojs": "^4.9.0",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0",
-        "react-dom": "^15.3.0 || ^16.0.0"
       }
     },
     "node_modules/react-is": {
@@ -6983,6 +7057,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -7048,7 +7123,8 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -7451,7 +7527,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.2.0.tgz",
       "integrity": "sha512-YLWysmaUBaC5wosAKkgbX7XI+LBv2w5L0QUcI6Jc4moHYzv9BUBJtAyNLpWzHjtjKTeWOH6bfP4a4pzf0UinfQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -7477,7 +7554,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-2.0.2.tgz",
       "integrity": "sha512-9WfT+FYBEvlrOOBEs484/zmbtSX4BlGjzXih1qIEWA1yhHbcqgcMHkiwXoWk2Sq1aJjLpcs6ZKV7JxrDNjIlNg==",
-      "license": "WTFPL"
+      "license": "WTFPL",
+      "peer": true
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -7511,7 +7589,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -7946,7 +8025,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
       "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-svg": {
       "version": "3.1.3",
@@ -8003,6 +8083,7 @@
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
@@ -8099,7 +8180,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/type-func/-/type-func-1.0.3.tgz",
       "integrity": "sha512-YA90CUk+i00tWESPNRMahywXhAz+12NLJLKlOWrgHIbqaFXjdZrWstRghaibOW/IxhPjui4SmXxO/03XSGRIjA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
@@ -8290,6 +8372,7 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8299,6 +8382,7 @@
       "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.3.tgz",
       "integrity": "sha512-qVkT1E7yMbUsB2mmJNFmaXMWE2hF8ffqzMMwe9zdAikd8u2VfnsVY2HQcOUi2F38bgbxzlJBEdS1UUhOXdF9GQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@sphinxxxx/color-conversion": "^2.2.2"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -11,15 +11,14 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@formio/react": "5.3.0",
     "@radix-ui/react-tabs": "^1.0.3",
     "@tanstack/react-query": "^5.24.0",
     "axios": "^1.12.2",
     "bpmn-js": "^17.11.1",
-    "formiojs": "^4.21.7",
     "lucide-react": "^0.298.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-formio": "^4.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.1"
   },
   "devDependencies": {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import Login from './pages/Login';
 import { ProjectPage } from './pages/ProjectPage';
 import ProjectsRedirect from './pages/ProjectsRedirect';
 import AdminDashboard from './pages/AdminDashboard';
+import FormRunner from './modules/pbc/FormRunner';
 import './index.css';
 
 export function LegacyReceptionRedirect() {
@@ -17,6 +18,7 @@ export function AppRouter() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<Login />} />
+        <Route path="/encuesta/:token" element={<FormRunner />} />
         <Route element={<ProtectedRoute />}>
           <Route path="/" element={<ProjectsRedirect />} />
           <Route path="/projects" element={<ProjectsRedirect />} />

--- a/web/src/modules/pbc/Builder.tsx
+++ b/web/src/modules/pbc/Builder.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
-import { FormBuilder } from 'react-formio';
-import 'formiojs/dist/css/formio.full.css';
+
+import EmbeddedFormioBuilder from './EmbeddedFormioBuilder';
 
 import api from '../../lib/api';
 
@@ -34,7 +34,7 @@ export function Builder({
       ? { id: templateIdProp, name: initialName ?? '', type: initialType }
       : null
   );
-  const [formSchema, setFormSchema] = useState<Record<string, unknown>>(
+  const [formSchema] = useState<Record<string, unknown>>(
     initialForm ?? { ...DEFAULT_FORM_SCHEMA }
   );
   const [name, setName] = useState(initialName ?? '');
@@ -179,11 +179,7 @@ export function Builder({
           </div>
         </div>
         <div className="mt-4">
-          <FormBuilder
-            form={formSchema as unknown}
-            onChange={(schema: Record<string, unknown>) => setFormSchema(schema)}
-            options={{ noDefaultSubmitButton: true }}
-          />
+          <EmbeddedFormioBuilder />
         </div>
       </section>
 

--- a/web/src/modules/pbc/EmbeddedFormioBuilder.tsx
+++ b/web/src/modules/pbc/EmbeddedFormioBuilder.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+
+/**
+ * Builder de Form.io embebido vía iframe.
+ * Requiere tener corriendo Form.io OSS (server + portal) y gestionar auth (SSO/JWT/Token).
+ * Ajusta la URL base y el proyecto/route según tu instalación.
+ */
+export default function EmbeddedFormioBuilder({
+  project = "default",
+  formPath = "auditoria-form", // ruta del form dentro de Form.io
+  baseUrl = import.meta.env.VITE_FORMIO_BASE_URL || "http://localhost:3001",
+}: {
+  project?: string;
+  formPath?: string;
+  baseUrl?: string;
+}) {
+  const builderUrl = useMemo(() => {
+    // Ejemplo de URL de builder en Form.io OSS; ajusta rutas según tu setup
+    // p.ej.: http://localhost:3001/project/default/form/auditoria-form/edit
+    const u = new URL(baseUrl);
+    u.pathname = `/project/${project}/form/${formPath}/edit`;
+    return u.toString();
+  }, [project, formPath, baseUrl]);
+
+  return (
+    <div className="w-full h-[85vh]">
+      <iframe
+        src={builderUrl}
+        className="w-full h-full border rounded-xl shadow-sm"
+        title="Form.io Builder"
+      />
+    </div>
+  );
+}

--- a/web/src/modules/pbc/FormRunner.tsx
+++ b/web/src/modules/pbc/FormRunner.tsx
@@ -1,172 +1,93 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Form } from 'react-formio';
-import 'formiojs/dist/css/formio.full.css';
+import { useEffect, useMemo, useState } from "react";
+import { Form } from "@formio/react";
 
-import api from '../../lib/api';
+/**
+ * Componente mínimo para renderizar un formulario Form.io.
+ *
+ * Usos:
+ * <FormRunner
+ *   formJson={schemaJson}
+ *   initialData={{ email: "user@demo.com" }}
+ *   onSubmit={(data) => apiSubmit(data)}
+ * />
+ *
+ * Si no pasas formJson, intentará cargarlo por token de la URL:
+ *   /encuesta/:token  -> GET /api/forms/links/:token  => { formJson }
+ */
+type Props = {
+  formJson?: any;
+  initialData?: Record<string, any>;
+  onSubmit?: (data: any) => Promise<void> | void;
+};
 
-interface FormRunnerProps {
-  token: string;
-  respondent?: {
-    email?: string;
-    fullName?: string;
-    department?: string;
-    externalId?: string;
-  };
-  autoSaveIntervalMs?: number;
-}
-
-interface FormMetadata {
-  form: Record<string, unknown>;
-  template: { id: string; name: string; type: string };
-}
-
-interface SubmissionState {
-  submissionId?: string;
-  scoreTotal?: number | null;
-  submittedAt?: string;
-}
-
-export function FormRunner({ token, respondent, autoSaveIntervalMs }: FormRunnerProps) {
-  const [metadata, setMetadata] = useState<FormMetadata | null>(null);
-  const [loading, setLoading] = useState(true);
+export default function FormRunner({ formJson, initialData, onSubmit }: Props) {
+  const [schema, setSchema] = useState<any>(formJson);
+  const [loading, setLoading] = useState<boolean>(!formJson);
   const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const [submission, setSubmission] = useState<SubmissionState | null>(null);
 
+  // Si no recibimos formJson por props, intentamos cargarlo por token en la ruta: /encuesta/:token
   useEffect(() => {
-    let isMounted = true;
-    const fetchForm = async () => {
-      setLoading(true);
-      setError(null);
+    if (formJson) return;
+    const token = window.location.pathname.split("/").pop();
+    if (!token) return;
+    (async () => {
       try {
-        const response = await api.get(`/forms/links/${token}`);
-        if (!isMounted) return;
-        setMetadata({
-          form: response.data.form,
-          template: response.data.template
-        });
-      } catch (err) {
-        if (!isMounted) return;
-        if (err instanceof Error) {
-          setError(err.message);
-        } else if (typeof err === 'object' && err && 'response' in err) {
-          const status = (err as { response?: { status?: number } }).response?.status;
-          setError(status === 410 ? 'El link expiró o alcanzó el máximo de respuestas.' : 'No se pudo cargar el formulario.');
-        } else {
-          setError('No se pudo cargar el formulario.');
-        }
+        setLoading(true);
+        const res = await fetch(`/api/forms/links/${encodeURIComponent(token)}`);
+        if (!res.ok) throw new Error(`Error ${res.status}`);
+        const payload = await res.json(); // { formJson: {...} }
+        setSchema(payload.formJson);
+        setError(null);
+      } catch (e: any) {
+        setError(e.message || "No se pudo cargar el formulario.");
       } finally {
-        if (isMounted) {
-          setLoading(false);
-        }
+        setLoading(false);
       }
-    };
-    void fetchForm();
-    return () => {
-      isMounted = false;
-    };
-  }, [token]);
+    })();
+  }, [formJson]);
 
-  const autoSave = useMemo(() => {
-    if (!autoSaveIntervalMs || autoSaveIntervalMs <= 0) {
-      return undefined;
-    }
-    return {
-      dataType: 'submission' as const,
-      saveDraft: true,
-      interval: autoSaveIntervalMs
-    };
-  }, [autoSaveIntervalMs]);
+  const formOptions = useMemo(
+    () => ({
+      readOnly: false,
+      noAlerts: false,
+      // habilita borradores si luego implementas autosave:
+      // saveDraft: true,
+    }),
+    []
+  );
 
-  const handleSubmit = async (submissionEvent: { data: Record<string, unknown> }) => {
-    setError(null);
-    setSubmitting(true);
-    try {
-      const response = await api.post(`/forms/submit/${token}`, {
-        answers: submissionEvent.data,
-        respondent
-      });
-      setSubmission(response.data as SubmissionState);
-    } catch (err) {
-      if (err instanceof Error) {
-        setError(err.message);
-      } else if (typeof err === 'object' && err && 'response' in err) {
-        const status = (err as { response?: { status?: number } }).response?.status;
-        if (status === 410) {
-          setError('El link expiró o alcanzó el máximo de respuestas.');
-        } else if (status === 401) {
-          setError('Debes iniciar sesión para completar este formulario.');
-        } else {
-          setError('No fue posible registrar la respuesta.');
-        }
-      } else {
-        setError('No fue posible registrar la respuesta.');
-      }
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  if (loading) {
-    return (
-      <div className="rounded-lg border border-slate-200 bg-white p-6 text-center text-sm text-slate-600 shadow-sm">
-        Cargando formulario…
-      </div>
-    );
-  }
-
-  if (error && !metadata) {
-    return (
-      <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-center text-sm text-rose-700 shadow-sm">
-        {error}
-      </div>
-    );
-  }
-
-  if (!metadata) {
-    return null;
-  }
+  if (loading) return <div className="p-4 text-sm">Cargando formulario…</div>;
+  if (error) return <div className="p-4 text-sm text-red-600">Error: {error}</div>;
+  if (!schema) return <div className="p-4 text-sm">Sin formulario disponible.</div>;
 
   return (
-    <div className="space-y-4">
-      <header className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-        <h1 className="text-lg font-semibold text-slate-900">{metadata.template.name}</h1>
-        <p className="text-sm text-slate-600">{metadata.template.type}</p>
-      </header>
-
-      <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-        <Form
-          form={metadata.form as unknown}
-          onSubmit={handleSubmit}
-          options={{
-            submitMessage: '',
-            noAlerts: true,
-            saveDraft: Boolean(autoSave)
-          }}
-          submission={{ data: {} }}
-          {...(autoSave ? { saveDraft: autoSave } : {})}
-        />
-      </section>
-
-      {submitting && (
-        <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm text-blue-700">
-          Enviando respuesta…
-        </div>
-      )}
-
-      {submission && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
-          ¡Respuesta registrada!{typeof submission.scoreTotal === 'number' ? ` Puntaje: ${submission.scoreTotal.toFixed(2)}.` : ''}
-        </div>
-      )}
-
-      {error && (
-        <div className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          {error}
-        </div>
-      )}
+    <div className="p-4">
+      <Form
+        form={schema}
+        submission={initialData ? { data: initialData } : undefined}
+        options={formOptions}
+        onSubmit={async (submission: any) => {
+          try {
+            if (onSubmit) {
+              await onSubmit(submission.data);
+              return;
+            }
+            // Por defecto, si estamos en /encuesta/:token, lo enviamos al endpoint de submit por token
+            const parts = window.location.pathname.split("/");
+            const token = parts[parts.length - 1];
+            if (!token) throw new Error("Token no encontrado en la URL.");
+            const res = await fetch(`/api/forms/submit/${encodeURIComponent(token)}`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(submission.data),
+            });
+            if (!res.ok) throw new Error(`Error al enviar (${res.status})`);
+            alert("Respuesta enviada con éxito.");
+          } catch (e: any) {
+            alert(`No se pudo enviar: ${e.message || e}`);
+          }
+        }}
+      />
     </div>
   );
 }
-
-export default FormRunner;

--- a/web/src/types/react-formio.d.ts
+++ b/web/src/types/react-formio.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-formio';


### PR DESCRIPTION
## Summary
- replace the legacy react-formio dependency with @formio/react and align React 18 versions
- introduce the minimal FormRunner component and an embedded Form.io builder while removing direct FormBuilder usage
- expose a public /encuesta/:token route for rendering Form.io links

## Testing
- npm install
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9d7e50004833190ba6a2fc487344a