### PR TITLE
Fix build failure due to bundled worker path

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
-    "build": "esbuild src/server.ts --platform=node --bundle --format=cjs --outfile=dist/server.cjs --sourcemap",
+    "build": "esbuild src/server.ts --platform=node --bundle --format=cjs --outfile=dist/server.cjs --sourcemap --packages=external",
     "start": "node dist/server.cjs",
     "prisma": "prisma",
     "migrate:deploy": "prisma migrate deploy",


### PR DESCRIPTION
## Summary
- ensure the API build keeps npm dependencies external when bundling with esbuild to avoid missing worker files at runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9dcaa9338833192a3647876208e30