### PR TITLE
Add surveys compatibility router

### DIFF
--- a/api/src/routes/surveys.ts
+++ b/api/src/routes/surveys.ts
@@ -1,0 +1,54 @@
+import { Router } from 'express';
+import type { Express, Request, Response } from 'express';
+
+const surveysRouter = Router();
+
+type ExpressRouter = {
+  handle: (req: Request, res: Response, next: () => void) => void;
+};
+
+type ExpressAppWithRouter = Express & {
+  _router?: ExpressRouter;
+};
+
+const forwardToForms = (req: Request, res: Response, url: string) => {
+  const appWithRouter = req.app as ExpressAppWithRouter;
+  const router = appWithRouter._router;
+
+  if (!router) {
+    res.status(500).json({ message: 'Router not initialized' });
+    return;
+  }
+
+  const forwardedRequest = Object.assign(
+    Object.create(Object.getPrototypeOf(req)),
+    req,
+    {
+      baseUrl: '',
+      url,
+      originalUrl: url
+    }
+  ) as Request;
+
+  router.handle.call(router, forwardedRequest, res, () => {});
+};
+
+/**
+ * Alias GET:
+ *   /api/surveys/:token  →  /api/forms/links/:token
+ */
+surveysRouter.get('/:token', (req: Request, res: Response) => {
+  const { token } = req.params;
+  forwardToForms(req, res, `/api/forms/links/${encodeURIComponent(token)}`);
+});
+
+/**
+ * Alias POST:
+ *   /api/surveys/:token  →  /api/forms/submit/:token
+ */
+surveysRouter.post('/:token', (req: Request, res: Response) => {
+  const { token } = req.params;
+  forwardToForms(req, res, `/api/forms/submit/${encodeURIComponent(token)}`);
+});
+
+export default surveysRouter;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -14,6 +14,7 @@ import { logger } from './core/config/logger.js';
 import { findingRouter } from './modules/findings/finding.router.js';
 import { riskRouter } from './modules/risks/risk.router.js';
 import { initializeQueueWorkers } from './services/queue.js';
+import surveysRouter from './routes/surveys.js';
 
 const app = express();
 
@@ -51,6 +52,7 @@ app.get('/metrics', async (_req, res) => {
 app.use('/api/risks', riskRouter);
 app.use('/api/findings', findingRouter);
 app.use('/api', appRouter);
+app.use('/api/surveys', surveysRouter);
 app.use(errorHandler);
 
 const server = app.listen(env.port, () => {


### PR DESCRIPTION
## Summary
- add a compatibility router that forwards survey requests to the existing form endpoints
- mount the surveys alias under `/api/surveys` to reuse the form routes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9ef9971388331a6720540fd07ebb7