### PR TITLE
Fix Docker build by copying Prisma schema before npm ci

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
+COPY prisma ./prisma
 RUN npm ci
 
-COPY prisma ./prisma
 RUN npm run generate
 
 # --- build ---


### PR DESCRIPTION
## Summary
- copy the prisma directory into the dependency stage before running npm ci so the postinstall hook can find schema.prisma

## Testing
- not run (docker unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68db3123d14083318d91677386967d86