### PR TITLE
Implement interview endpoints and restore schema fields

### DIFF
--- a/api/prisma/migrations/20250930040000_restore_interview_fields/migration.sql
+++ b/api/prisma/migrations/20250930040000_restore_interview_fields/migration.sql
@@ -1,0 +1,24 @@
+-- AlterTable
+ALTER TABLE "Interview"
+  ADD COLUMN "personName" TEXT DEFAULT 'Entrevista pendiente',
+  ADD COLUMN "role" TEXT,
+  ADD COLUMN "area" TEXT,
+  ADD COLUMN "date" TIMESTAMP(3),
+  ADD COLUMN "transcript" TEXT,
+  ADD COLUMN "audioFileId" TEXT,
+  ALTER COLUMN "versionId" DROP NOT NULL,
+  ALTER COLUMN "status" DROP NOT NULL,
+  ALTER COLUMN "status" SET DEFAULT 'draft';
+
+-- Backfill mandatory values for the new personName column
+UPDATE "Interview"
+SET "personName" = COALESCE("personName", 'Entrevista pendiente');
+
+-- Ensure the column is required going forward
+ALTER TABLE "Interview"
+  ALTER COLUMN "personName" SET NOT NULL,
+  ALTER COLUMN "personName" DROP DEFAULT;
+
+-- Add foreign key for optional audio file attachments
+ALTER TABLE "Interview"
+  ADD CONSTRAINT "Interview_audioFileId_fkey" FOREIGN KEY ("audioFileId") REFERENCES "File"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -109,6 +109,7 @@ model File {
   /// LADOS OPUESTOS (NUEVOS) — ¡IMPORTANTE nombrar las relaciones!
   dataRequestItems DataRequestItem[] @relation(name: "FileToDataRequestItems")
   processAssets    ProcessAsset[]    @relation(name: "FileToProcessAssets")
+  interviewAudio   Interview[]       @relation(name: "FileToInterviewAudio")
 }
 
 model DataRequestItem {
@@ -264,21 +265,28 @@ model Respondent {
 }
 
 model Interview {
-  id            String               @id @default(cuid())
-  versionId     String
+  id            String                @id @default(cuid())
   projectId     String
+  personName    String
+  role          String?
+  area          String?
+  date          DateTime?
+  transcript    String?
+  notes         String?
+  audioFileId   String?
+  versionId     String?
   interviewerId String
   respondentId  String?
-  status        String
+  status        String?               @default("draft")
   startedAt     DateTime?
   finishedAt    DateTime?
-  notes         String?
   audioKey      String?
-  createdAt     DateTime             @default(now())
-  version       QuestionnaireVersion @relation(fields: [versionId], references: [id])
-  project       Project              @relation(fields: [projectId], references: [id])
-  interviewer   User                 @relation(fields: [interviewerId], references: [id])
-  respondent    Respondent?          @relation(fields: [respondentId], references: [id])
+  createdAt     DateTime              @default(now())
+  version       QuestionnaireVersion? @relation(fields: [versionId], references: [id])
+  project       Project               @relation(fields: [projectId], references: [id])
+  interviewer   User                  @relation(fields: [interviewerId], references: [id])
+  respondent    Respondent?           @relation(fields: [respondentId], references: [id])
+  audioFile     File?                 @relation(name: "FileToInterviewAudio", fields: [audioFileId], references: [id])
 
   @@index([projectId])
   @@index([versionId])

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -18,6 +18,7 @@ import { auditRouter } from './modules/audit/audit.router.js';
 import { fileRouter } from './modules/files/file.router.js';
 import { projectPlanRouter } from './modules/projectPlan/project-plan.router.js';
 import { reportRouter } from './modules/reports/report.router.js';
+import { interviewRouter } from './modules/interviews/interview.router.js';
 
 const appRouter = Router();
 
@@ -39,5 +40,6 @@ appRouter.use('/audit', auditRouter);
 appRouter.use('/files', fileRouter);
 appRouter.use('/project-plan', projectPlanRouter);
 appRouter.use('/reports', reportRouter);
+appRouter.use('/interviews', interviewRouter);
 
 export { appRouter };

--- a/api/src/modules/interviews/interview.router.ts
+++ b/api/src/modules/interviews/interview.router.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+
+import { authenticate, requireProjectRole } from '../../core/middleware/auth.js';
+import { enforceProjectAccess } from '../../core/security/enforce-project-access.js';
+import { interviewService } from './interview.service.js';
+
+const readRoles = ['ConsultorLider', 'Auditor', 'SponsorPM', 'Invitado'];
+const writeRoles = ['ConsultorLider', 'Auditor'];
+
+const interviewRouter = Router();
+
+interviewRouter.use(authenticate);
+
+interviewRouter.get('/:projectId', requireProjectRole(readRoles), async (req, res) => {
+  await enforceProjectAccess(req.user!, req.params.projectId);
+  const interviews = await interviewService.list(req.params.projectId);
+  res.json(interviews);
+});
+
+interviewRouter.post('/:projectId', requireProjectRole(writeRoles), async (req, res) => {
+  const interview = await interviewService.create(req.params.projectId, req.body, req.user!);
+  res.status(201).json(interview);
+});
+
+interviewRouter.put('/:projectId/:interviewId', requireProjectRole(writeRoles), async (req, res) => {
+  const interview = await interviewService.update(
+    req.params.projectId,
+    req.params.interviewId,
+    req.body,
+    req.user!
+  );
+  res.json(interview);
+});
+
+interviewRouter.delete('/:projectId/:interviewId', requireProjectRole(['ConsultorLider']), async (req, res) => {
+  await interviewService.remove(req.params.projectId, req.params.interviewId, req.user!);
+  res.status(204).send();
+});
+
+export { interviewRouter };

--- a/api/src/modules/interviews/interview.service.ts
+++ b/api/src/modules/interviews/interview.service.ts
@@ -1,0 +1,108 @@
+import { prisma } from '../../core/config/db.js';
+import { HttpError } from '../../core/errors/http-error.js';
+import type { AuthenticatedRequest } from '../../core/middleware/auth.js';
+import { auditService } from '../audit/audit.service.js';
+
+interface InterviewPayload {
+  personName: string;
+  role?: string | null;
+  area?: string | null;
+  date?: string | null;
+  transcript?: string | null;
+  notes?: string | null;
+}
+
+const sanitizePayload = (payload: InterviewPayload) => {
+  const personName = (payload.personName ?? '').trim();
+  if (!personName) {
+    throw new HttpError(400, 'El nombre del entrevistado es obligatorio');
+  }
+
+  const role = payload.role ? payload.role.trim() : null;
+  const area = payload.area ? payload.area.trim() : null;
+  const transcript = payload.transcript ? payload.transcript.trim() : null;
+  const notes = payload.notes ? payload.notes.trim() : null;
+
+  let date: Date | null = null;
+  if (payload.date) {
+    const parsed = new Date(payload.date);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new HttpError(400, 'La fecha de la entrevista es inválida');
+    }
+    date = parsed;
+  }
+
+  return { personName, role, area, transcript, notes, date };
+};
+
+export const interviewService = {
+  async list(projectId: string) {
+    return prisma.interview.findMany({
+      where: { projectId },
+      orderBy: [
+        { date: 'desc' },
+        { createdAt: 'desc' }
+      ]
+    });
+  },
+
+  async create(projectId: string, payload: InterviewPayload, user: NonNullable<AuthenticatedRequest['user']>) {
+    const data = sanitizePayload(payload);
+
+    const interview = await prisma.interview.create({
+      data: {
+        projectId,
+        personName: data.personName,
+        role: data.role,
+        area: data.area,
+        date: data.date,
+        transcript: data.transcript,
+        notes: data.notes,
+        interviewerId: user.id,
+        status: 'completed'
+      }
+    });
+
+    await auditService.record('Interview', interview.id, 'CREATE', user.id, projectId, null, interview);
+    return interview;
+  },
+
+  async update(
+    projectId: string,
+    interviewId: string,
+    payload: InterviewPayload,
+    user: NonNullable<AuthenticatedRequest['user']>
+  ) {
+    const existing = await prisma.interview.findUnique({ where: { id: interviewId } });
+    if (!existing || existing.projectId !== projectId) {
+      throw new HttpError(404, 'Entrevista no encontrada');
+    }
+
+    const data = sanitizePayload(payload);
+
+    const updated = await prisma.interview.update({
+      where: { id: interviewId },
+      data: {
+        personName: data.personName,
+        role: data.role,
+        area: data.area,
+        date: data.date,
+        transcript: data.transcript,
+        notes: data.notes
+      }
+    });
+
+    await auditService.record('Interview', interviewId, 'UPDATE', user.id, projectId, existing, updated);
+    return updated;
+  },
+
+  async remove(projectId: string, interviewId: string, user: NonNullable<AuthenticatedRequest['user']>) {
+    const existing = await prisma.interview.findUnique({ where: { id: interviewId } });
+    if (!existing || existing.projectId !== projectId) {
+      throw new HttpError(404, 'Entrevista no encontrada');
+    }
+
+    await prisma.interview.delete({ where: { id: interviewId } });
+    await auditService.record('Interview', interviewId, 'DELETE', user.id, projectId, existing, null);
+  }
+};


### PR DESCRIPTION
## Summary
- restore legacy interview fields in Prisma while keeping questionnaire linkage optional and add a migration
- add an interview service and router with audit logging and project role enforcement
- expose the interview API through the main application router

## Testing
- npm run lint *(fails: existing ESLint configuration cannot parse many project files; see log)*

------
https://chatgpt.com/codex/tasks/task_e_68db44f1cbf883318a79f2ca4f4b8aaf