### PR TITLE
Fix chartjs dependency and install node-canvas system libs

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,7 +3,9 @@ FROM node:18-bullseye-slim AS deps
 WORKDIR /usr/src/app
 # utilidades que prisma suele requerir
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  openssl ca-certificates python3 build-essential \
+  openssl ca-certificates python3 git build-essential \
+  libcairo2-dev libpango1.0-dev \
+  libjpeg-dev libgif-dev librsvg2-dev \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./

--- a/api/package.json
+++ b/api/package.json
@@ -23,7 +23,7 @@
     "bullmq": "^5.22.0",
     "bcryptjs": "^2.4.3",
     "chart.js": "4.4.1",
-    "chartjs-node-canvas": "4.1.7",
+    "chartjs-node-canvas": "4.1.6",
     "cors": "^2.8.5",
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
## Summary
- pin `chartjs-node-canvas` to the existing 4.1.6 release while keeping chart.js at 4.4.1
- install the native libraries required by node-canvas in the API Docker image deps stage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf0c8c9cc8331a5e5916d4e50277e