### PR TITLE
Install curl in API runner image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -33,6 +33,9 @@ RUN npm run build
 FROM node:18-bullseye-slim AS runner
 WORKDIR /usr/src/app
 ENV NODE_ENV=production
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/*
 # Solo lo necesario para correr
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist


### PR DESCRIPTION
## Summary
- install curl in the API runner stage so the health check can run
- clear the apt cache after installing curl

## Testing
- docker compose build api *(fails: `docker` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc02c208f08331a920e1c1650019cc