### PR TITLE
Add acceptance workflow script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,20 @@ Suite full-stack para gestionar auditorías multi-proyecto con módulos especial
 4. [Estructura del repositorio](#estructura-del-repositorio)
 5. [Requisitos](#requisitos)
 6. [Primeros pasos](#primeros-pasos)
-7. [Configuración sin Docker](#configuración-sin-docker)
-8. [Variables de entorno](#variables-de-entorno)
-9. [Módulos clave](#módulos-clave)
-10. [Gestión de proyectos y empresas](#gestión-de-proyectos-y-empresas)
-11. [Scripts útiles](#scripts-útiles)
-12. [Semilla de datos](#semilla-de-datos)
-13. [OpenAPI y clientes](#openapi-y-clientes)
-14. [Tests y calidad](#tests-y-calidad)
-15. [Despliegue](#despliegue)
-16. [Resolución de problemas](#resolución-de-problemas)
-17. [FAQ](#faq)
-18. [Contribuir](#contribuir)
-19. [Licencia](#licencia)
+7. [Arranque rápido estable](#arranque-rápido-estable)
+8. [Configuración sin Docker](#configuración-sin-docker)
+9. [Variables de entorno](#variables-de-entorno)
+10. [Módulos clave](#módulos-clave)
+11. [Gestión de proyectos y empresas](#gestión-de-proyectos-y-empresas)
+12. [Scripts útiles](#scripts-útiles)
+13. [Semilla de datos](#semilla-de-datos)
+14. [OpenAPI y clientes](#openapi-y-clientes)
+15. [Tests y calidad](#tests-y-calidad)
+16. [Despliegue](#despliegue)
+17. [Resolución de problemas](#resolución-de-problemas)
+18. [FAQ](#faq)
+19. [Contribuir](#contribuir)
+20. [Licencia](#licencia)
 
 ## Visión general
 
@@ -103,6 +104,20 @@ Auditoría centraliza el proceso completo de auditorías operacionales, desde la
    ```
 
 La API esperará a que la base de datos esté disponible y aplicará `prisma migrate deploy` automáticamente en cada arranque del contenedor.
+
+## Arranque rápido estable
+
+Ejecuta los siguientes comandos en una terminal limpia para dejar la pila estable y lista para revisar:
+
+```bash
+cp .env.development .env
+npm install --prefix api
+npm install --prefix web
+./scripts/compose.sh up -d --build
+./scripts/accept.sh
+```
+
+El script `./scripts/accept.sh` usa Docker Compose por defecto para ejecutar migraciones y semillas (define `ACCEPT_USE_DOCKER=0` si prefieres correrlas contra servicios locales), espera a que `http://localhost:4000/api/health` responda correctamente y compila el frontend tras validar la salud de la API.
 
 ### Builds detrás de un proxy corporativo
 

--- a/scripts/accept.sh
+++ b/scripts/accept.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_CMD="${COMPOSE_CMD:-$ROOT_DIR/scripts/compose.sh}"
+USE_DOCKER="${ACCEPT_USE_DOCKER:-1}"
+WAIT_SCRIPT="$ROOT_DIR/scripts/wait-on.sh"
+HEALTH_URL="${ACCEPT_HEALTH_URL:-http://localhost:4000/api/health}"
+WAIT_TIMEOUT="${ACCEPT_HEALTH_TIMEOUT:-180}"
+WAIT_INTERVAL="${ACCEPT_HEALTH_INTERVAL:-3}"
+
+info() {
+  printf '\n[accept] %s\n' "$*"
+}
+
+run_in_dir() {
+  local dir="$1"
+  shift
+  (cd "$dir" && "$@")
+}
+
+run_api() {
+  if [[ "$USE_DOCKER" == "1" ]]; then
+    if [[ ! -x "$COMPOSE_CMD" ]]; then
+      echo "Docker compose helper not found at $COMPOSE_CMD" >&2
+      exit 1
+    fi
+    "$COMPOSE_CMD" exec -T api "$@"
+  else
+    run_in_dir "$ROOT_DIR/api" "$@"
+  fi
+}
+
+if [[ ! -x "$WAIT_SCRIPT" ]]; then
+  echo "Helper $WAIT_SCRIPT must be executable" >&2
+  exit 1
+fi
+
+info "Linting API"
+run_in_dir "$ROOT_DIR/api" npm run lint
+
+info "Type-checking API"
+run_in_dir "$ROOT_DIR/api" npx tsc --noEmit
+
+info "Linting Web"
+run_in_dir "$ROOT_DIR/web" npm run lint
+
+info "Type-checking Web"
+run_in_dir "$ROOT_DIR/web" npx tsc --noEmit
+
+info "Running database migrations"
+run_api npm run migrate:deploy
+
+info "Seeding database"
+run_api npm run seed
+
+info "Waiting for API health at $HEALTH_URL"
+"$WAIT_SCRIPT" "$HEALTH_URL" "$WAIT_TIMEOUT" "$WAIT_INTERVAL"
+
+info "Fetching API health"
+curl --fail --show-error --silent "$HEALTH_URL"
+
+info "Building web application"
+run_in_dir "$ROOT_DIR/web" npm run build
+
+info "Acceptance workflow completed"

--- a/scripts/wait-on.sh
+++ b/scripts/wait-on.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  cat >&2 <<'USAGE'
+Usage: scripts/wait-on.sh <url> [timeout_seconds] [interval_seconds]
+
+Polls an HTTP endpoint until it responds successfully or the timeout is reached.
+USAGE
+  exit 1
+fi
+
+URL="$1"
+TIMEOUT="${2:-120}"
+INTERVAL="${3:-2}"
+
+if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || ! [[ "$INTERVAL" =~ ^[0-9]+$ ]]; then
+  echo "Timeout and interval must be positive integers" >&2
+  exit 1
+fi
+
+end_time=$(( $(date +%s) + TIMEOUT ))
+
+while true; do
+  if curl --fail --silent --output /dev/null "$URL"; then
+    exit 0
+  fi
+
+  if (( $(date +%s) >= end_time )); then
+    echo "Timed out waiting for $URL after ${TIMEOUT}s" >&2
+    exit 1
+  fi
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- add `scripts/accept.sh` to run linting, type-checks, migrations, seed, health checks and web build
- add helper script `scripts/wait-on.sh` to poll the API health endpoint
- document a five-step “Arranque rápido estable” quick-start sequence in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc0400123c8331881adaf699686708