### PR TITLE
feat: harden base environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ web/dist
 *.env
 *.env.*
 !/.env.example
+!**/.env.example
 !.env.development
 !.env.production

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Auditoría centraliza el proceso completo de auditorías operacionales, desde la
 - Docker y Docker Compose (opcional pero recomendado)
 - PostgreSQL local (solo si decides no usar Docker)
 
+## Setup rápido
+
+1. Copia el archivo `.env.development` a `.env` para reutilizar las variables por defecto.
+2. Levanta la base de datos con `docker compose up -d db`.
+3. Arranca API y frontend con `docker compose up -d api web` y comprueba `http://localhost:4000/health`.
+
 ## Primeros pasos
 
 1. Clona el repositorio.
@@ -100,7 +106,7 @@ Auditoría centraliza el proceso completo de auditorías operacionales, desde la
    ```
 5. Accede a la web en `http://localhost:5173` y valida la salud de la API con:
    ```bash
-   curl http://localhost:4000/api/health
+   curl http://localhost:4000/health
    ```
 
 La API esperará a que la base de datos esté disponible y aplicará `prisma migrate deploy` automáticamente en cada arranque del contenedor.
@@ -117,7 +123,7 @@ npm install --prefix web
 ./scripts/accept.sh
 ```
 
-El script `./scripts/accept.sh` usa Docker Compose por defecto para ejecutar migraciones y semillas (define `ACCEPT_USE_DOCKER=0` si prefieres correrlas contra servicios locales), espera a que `http://localhost:4000/api/health` responda correctamente y compila el frontend tras validar la salud de la API.
+El script `./scripts/accept.sh` usa Docker Compose por defecto para ejecutar migraciones y semillas (define `ACCEPT_USE_DOCKER=0` si prefieres correrlas contra servicios locales), espera a que `http://localhost:4000/health` responda correctamente y compila el frontend tras validar la salud de la API.
 
 ### Builds detrás de un proxy corporativo
 
@@ -270,7 +276,7 @@ docker compose down -v
 cp .env.example .env
 docker compose up -d --build
 
-curl -i http://localhost:4000/api/health
+curl -i http://localhost:4000/health
 TOKEN=$(curl -s -X POST http://localhost:4000/api/auth/login \
   -H 'content-type: application/json' \
   -d '{"email":"admin@demo.com","password":"demo123"}' | jq -r '.accessToken')

--- a/api/package.json
+++ b/api/package.json
@@ -8,9 +8,11 @@
     "build": "esbuild src/server.ts --platform=node --bundle --format=cjs --outfile=dist/server.cjs --sourcemap --packages=external",
     "start": "node dist/server.cjs",
     "prisma": "prisma",
+    "dev:db:migrate": "prisma migrate dev",
+    "db:seed": "ts-node --esm prisma/seed.ts",
     "migrate:deploy": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev",
-    "seed": "node prisma/seed.js",
+    "seed": "npm run db:seed",
     "generate": "prisma generate",
     "postinstall": "prisma generate",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
@@ -75,6 +77,6 @@
     "typescript": "^5.3.3"
   },
   "prisma": {
-    "seed": "node prisma/seed.js"
+    "seed": "ts-node --esm prisma/seed.ts"
   }
 }

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -2,10 +2,10 @@ import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
-import { PrismaClient, ProjectWorkflowState } from '@prisma/client';
+import { PrismaClient, ProjectWorkflowState, Prisma } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 
-const runMigrations = () => {
+const runMigrations = (): void => {
   if (process.env.SKIP_MIGRATE_ON_SEED === 'true') {
     console.log('[seed] SKIP_MIGRATE_ON_SEED=true, omitiendo prisma migrate deploy');
     return;
@@ -28,7 +28,7 @@ runMigrations();
 
 const prisma = new PrismaClient();
 
-const ensureWorkflowEnum = () => {
+const ensureWorkflowEnum = (): void => {
   const expected = [
     'planificacion',
     'recoleccion_datos',
@@ -46,7 +46,9 @@ const ensureWorkflowEnum = () => {
   }
 };
 
-async function upsertUser(email, name, role, password) {
+type UserRole = Prisma.UserCreateInput['role'];
+
+async function upsertUser(email: string, name: string, role: UserRole, password: string) {
   const passwordHash = await bcrypt.hash(password, 10);
   return prisma.user.upsert({
     where: { email },
@@ -55,7 +57,7 @@ async function upsertUser(email, name, role, password) {
   });
 }
 
-async function findOrCreateCompany(name, taxId) {
+async function findOrCreateCompany(name: string, taxId: string) {
   const existing = await prisma.company.findFirst({ where: { name } });
   if (existing) {
     return existing;
@@ -63,7 +65,7 @@ async function findOrCreateCompany(name, taxId) {
   return prisma.company.create({ data: { name, taxId } });
 }
 
-async function main() {
+async function main(): Promise<void> {
   ensureWorkflowEnum();
   const nutrial = await findOrCreateCompany('Nutrial', '76.543.210-9');
   const democorp = await findOrCreateCompany('DemoCorp', '76.000.000-0');

--- a/api/src/common/validation/helpers.ts
+++ b/api/src/common/validation/helpers.ts
@@ -1,0 +1,14 @@
+import { ZodError, ZodIssue } from 'zod';
+
+export type ValidationIssue = {
+  path: string;
+  message: string;
+  code: ZodIssue['code'];
+};
+
+export const formatZodIssues = (error: ZodError): ValidationIssue[] =>
+  error.issues.map((issue) => ({
+    path: issue.path.join('.') || '<root>',
+    message: issue.message,
+    code: issue.code,
+  }));

--- a/api/src/common/validation/index.ts
+++ b/api/src/common/validation/index.ts
@@ -1,0 +1,3 @@
+export * from './helpers.js';
+export * from './request-validator.js';
+export * from './zod-error.middleware.js';

--- a/api/src/common/validation/request-validator.ts
+++ b/api/src/common/validation/request-validator.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from 'express';
+import type { ZodTypeAny } from 'zod';
+
+export type RequestValidationSchema = {
+  body?: ZodTypeAny;
+  params?: ZodTypeAny;
+  query?: ZodTypeAny;
+};
+
+const parsePart = (schema: ZodTypeAny | undefined, value: unknown) =>
+  schema ? schema.parse(value) : value;
+
+export const validateRequest = (schemas: RequestValidationSchema): RequestHandler => {
+  return (req, _res, next) => {
+    try {
+      if (schemas.body) {
+        req.body = parsePart(schemas.body, req.body);
+      }
+      if (schemas.params) {
+        req.params = parsePart(schemas.params, req.params);
+      }
+      if (schemas.query) {
+        req.query = parsePart(schemas.query, req.query);
+      }
+      next();
+    } catch (error) {
+      next(error);
+    }
+  };
+};

--- a/api/src/common/validation/zod-error.middleware.ts
+++ b/api/src/common/validation/zod-error.middleware.ts
@@ -1,0 +1,22 @@
+import type { NextFunction, Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+import { formatZodIssues } from './helpers.js';
+
+export const zodErrorHandler = (err: unknown, req: Request, res: Response, next: NextFunction) => {
+  if (!(err instanceof ZodError)) {
+    next(err);
+    return;
+  }
+
+  const problem = {
+    type: 'https://httpstatuses.com/422',
+    title: 'Unprocessable Entity',
+    status: 422,
+    detail: 'La solicitud contiene datos inválidos.',
+    errors: formatZodIssues(err),
+    ...(req.id ? { instance: req.id } : {}),
+  } as const;
+
+  res.status(422).json(problem);
+};

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -20,6 +20,7 @@ import workflowRouter from './modules/workflow/workflow.router.js';
 import reportRouter from './modules/export/report.router.js';
 import { initializeQueueWorkers } from './services/queue.js';
 import surveysRouter from './routes/surveys.js';
+import { zodErrorHandler } from './common/validation/zod-error.middleware.js';
 
 const app = express();
 
@@ -91,7 +92,7 @@ app.use(globalRateLimiter);
 app.use(json());
 app.use(urlencoded({ extended: true }));
 
-app.get('/api/health', (_req, res) => res.json({ ok: true }));
+app.get(['/health', '/api/health'], (_req, res) => res.json({ ok: true }));
 app.get('/metrics', async (_req, res) => {
   res.setHeader('Content-Type', metricsRegistry.contentType);
   res.send(await metricsRegistry.metrics());
@@ -115,6 +116,7 @@ app.use((req, res) => {
 
   res.status(404).json(problem);
 });
+app.use(zodErrorHandler);
 app.use(errorHandler);
 
 const server = app.listen(env.port, () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     env_file:
       - .env
     environment:
-      NODE_ENV: ${NODE_ENV:-development}
+      NODE_ENV: development
       DATABASE_URL: ${DATABASE_URL}
       JWT_SECRET: ${JWT_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
@@ -60,15 +60,18 @@ services:
       RATE_LIMIT_MAX: ${RATE_LIMIT_MAX:-300}
       LOGIN_RATE_LIMIT_WINDOW_MS: ${LOGIN_RATE_LIMIT_WINDOW_MS:-900000}
       LOGIN_RATE_LIMIT_MAX: ${LOGIN_RATE_LIMIT_MAX:-10}
+      PRISMA_LOG: query,error,warn
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     ports:
       - "${API_PORT:-4000}:4000"
     volumes:
       - api-storage:/usr/src/app/storage
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:${API_PORT:-4000}/api/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:${API_PORT:-4000}/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/scripts/accept.sh
+++ b/scripts/accept.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_CMD="${COMPOSE_CMD:-$ROOT_DIR/scripts/compose.sh}"
 USE_DOCKER="${ACCEPT_USE_DOCKER:-1}"
 WAIT_SCRIPT="$ROOT_DIR/scripts/wait-on.sh"
-HEALTH_URL="${ACCEPT_HEALTH_URL:-http://localhost:4000/api/health}"
+HEALTH_URL="${ACCEPT_HEALTH_URL:-http://localhost:4000/health}"
 WAIT_TIMEOUT="${ACCEPT_HEALTH_TIMEOUT:-180}"
 WAIT_INTERVAL="${ACCEPT_HEALTH_INTERVAL:-3}"
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,2 @@
+# URL base de la API consumida por el frontend
+VITE_API_URL=http://localhost:4000/api


### PR DESCRIPTION
## Summary
- ensure docker compose starts services with deterministic env vars, health checks and Prisma logging enabled
- port the Prisma seed script to TypeScript and expose helper npm scripts for migrations and seeding
- add reusable Zod validation helpers plus middleware wiring, expose the new /health endpoint, and document quick setup along with frontend env guidance

## Testing
- npm --prefix api run lint *(fails: existing lint configuration cannot resolve TypeScript sources throughout the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68deca3a39108331a59c5ed021c29623