### PR TITLE
Add 5S audits support

### DIFF
--- a/api/prisma/migrations/20251015090000_add_five_s_audits/migration.sql
+++ b/api/prisma/migrations/20251015090000_add_five_s_audits/migration.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "FiveS_Audit" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "area" TEXT NOT NULL,
+    "score" DOUBLE PRECISION NOT NULL,
+    "auditDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "photos" JSONB NOT NULL DEFAULT '[]',
+    "actions" JSONB NOT NULL DEFAULT '[]',
+    "notes" TEXT,
+    "createdById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FiveS_Audit_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "FiveS_Audit_projectId_idx" ON "FiveS_Audit"("projectId");
+CREATE INDEX "FiveS_Audit_auditDate_idx" ON "FiveS_Audit"("auditDate");
+
+ALTER TABLE "FiveS_Audit" ADD CONSTRAINT "FiveS_Audit_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "FiveS_Audit" ADD CONSTRAINT "FiveS_Audit_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -110,6 +110,7 @@ model Project {
   barcodeLabels          BarcodeLabel[]
   skuDupCandidates       SkuDupCandidate[]
   inventoryCounts        InventoryCount[]
+  fiveSAudits            FiveSAudit[]
   auditLogs              AuditLog[]
   questionnaireResponses QuestionnaireResponse[]
   surveyLinks            SurveyLink[]
@@ -139,11 +140,32 @@ model User {
   signedChecklists      Checklist[]             @relation("ChecklistSignedBy")
   installedLabels       BarcodeLabel[]          @relation("BarcodeInstalledBy")
   inventoryTasks        InventoryTask[]         @relation("InventoryTaskAssignedTo")
+  fiveSAudits           FiveSAudit[]            @relation("FiveSAuditCreatedBy")
   createdAt             DateTime                @default(now())
   updatedAt             DateTime                @updatedAt
   QuestionnaireTemplate QuestionnaireTemplate[]
   SurveyLink            SurveyLink[]
   Interview             Interview[]
+}
+
+model FiveSAudit {
+  id           String   @id @default(cuid())
+  projectId    String
+  project      Project  @relation(fields: [projectId], references: [id])
+  area         String
+  score        Float
+  auditDate    DateTime @default(now())
+  photos       Json     @default("[]")
+  actions      Json     @default("[]")
+  notes        String?
+  createdById  String?
+  createdBy    User?    @relation("FiveSAuditCreatedBy", fields: [createdById], references: [id])
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@map("FiveS_Audit")
+  @@index([projectId], name: "FiveS_Audit_projectId_idx")
+  @@index([auditDate], name: "FiveS_Audit_auditDate_idx")
 }
 
 model Membership {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -30,6 +30,7 @@ import { projectPlanRouter } from './modules/projectPlan/project-plan.router.js'
 import { reportRouter } from './modules/reports/report.router.js';
 import { interviewRouter } from './modules/interviews/interview.router.js';
 import { inventoryRouter } from './modules/inventory/inventory.router.js';
+import { fiveSRouter } from './modules/fiveS/five-s.router.js';
 
 const appRouter = Router();
 
@@ -63,5 +64,6 @@ appRouter.use('/project-plan', projectPlanRouter);
 appRouter.use('/reports', reportRouter);
 appRouter.use('/interviews', interviewRouter);
 appRouter.use('/inventory', inventoryRouter);
+appRouter.use('/fiveS', fiveSRouter);
 
 export { appRouter };

--- a/api/src/modules/fiveS/five-s-audit.service.ts
+++ b/api/src/modules/fiveS/five-s-audit.service.ts
@@ -1,0 +1,166 @@
+import { Prisma } from '@prisma/client';
+import { z } from 'zod';
+
+import { prisma } from '../../core/config/db.js';
+import { HttpError } from '../../core/errors/http-error.js';
+import { auditService } from '../audit/audit.service.js';
+
+const photoSchema = z.object({
+  type: z.enum(['before', 'after']),
+  url: z.string().trim().min(1, 'La URL de la foto es obligatoria'),
+  description: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined))
+});
+
+const actionSchema = z.object({
+  description: z
+    .string()
+    .trim()
+    .min(1, 'La descripción de la acción es obligatoria'),
+  responsible: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
+  dueDate: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
+  status: z.enum(['todo', 'in_progress', 'done']).default('todo'),
+  notes: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined))
+});
+
+const createSchema = z.object({
+  area: z.string().trim().min(1, 'El área es obligatoria'),
+  score: z.coerce
+    .number()
+    .min(0, 'La puntuación debe ser mayor o igual a 0')
+    .max(5, 'La puntuación máxima es 5'),
+  auditDate: z.coerce.date().optional(),
+  notes: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
+  photos: z.array(photoSchema).default([]),
+  actions: z.array(actionSchema).default([])
+});
+
+const updateSchema = createSchema.partial();
+
+const toJsonArray = (
+  value: z.infer<typeof photoSchema>[] | z.infer<typeof actionSchema>[]
+) => value as unknown as Prisma.JsonArray;
+
+export const fiveSAuditService = {
+  async list(projectId: string) {
+    return prisma.fiveSAudit.findMany({
+      where: { projectId },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true
+          }
+        }
+      },
+      orderBy: [{ auditDate: 'desc' }, { createdAt: 'desc' }]
+    });
+  },
+
+  async create(projectId: string, payload: unknown, userId: string) {
+    const data = createSchema.parse(payload);
+    const created = await prisma.fiveSAudit.create({
+      data: {
+        projectId,
+        area: data.area,
+        score: data.score,
+        auditDate: data.auditDate ?? new Date(),
+        notes: data.notes ?? null,
+        photos: toJsonArray(data.photos),
+        actions: toJsonArray(data.actions),
+        createdById: userId
+      },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true
+          }
+        }
+      }
+    });
+
+    await auditService.record(
+      'FiveS_Audit',
+      created.id,
+      'CREATE',
+      userId,
+      projectId,
+      null,
+      created
+    );
+
+    return created;
+  },
+
+  async update(id: string, payload: unknown, userId: string) {
+    const existing = await prisma.fiveSAudit.findUnique({ where: { id } });
+    if (!existing) {
+      throw new HttpError(404, 'Auditoría 5S no encontrada');
+    }
+
+    const data = updateSchema.parse(payload);
+
+    const updated = await prisma.fiveSAudit.update({
+      where: { id },
+      data: {
+        area: data.area,
+        score: data.score,
+        auditDate: data.auditDate,
+        notes: data.notes === undefined ? undefined : (data.notes ?? null),
+        photos: data.photos ? toJsonArray(data.photos) : undefined,
+        actions: data.actions ? toJsonArray(data.actions) : undefined
+      },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true
+          }
+        }
+      }
+    });
+
+    await auditService.record(
+      'FiveS_Audit',
+      id,
+      'UPDATE',
+      userId,
+      existing.projectId,
+      existing,
+      updated
+    );
+
+    return updated;
+  },
+
+  async getProjectId(auditId: string) {
+    const audit = await prisma.fiveSAudit.findUnique({
+      where: { id: auditId },
+      select: { projectId: true }
+    });
+    if (!audit) {
+      throw new HttpError(404, 'Auditoría 5S no encontrada');
+    }
+    return audit.projectId;
+  }
+};

--- a/api/src/modules/fiveS/five-s.router.ts
+++ b/api/src/modules/fiveS/five-s.router.ts
@@ -1,0 +1,60 @@
+import { Router } from 'express';
+
+import {
+  authenticate,
+  requireProjectRole,
+  type AuthenticatedRequest
+} from '../../core/middleware/auth.js';
+import { enforceProjectAccess } from '../../core/security/enforce-project-access.js';
+import { fiveSAuditService } from './five-s-audit.service.js';
+
+const viewerRoles = ['ConsultorLider', 'Auditor', 'SponsorPM', 'Invitado'];
+const editorRoles = ['ConsultorLider', 'Auditor'];
+
+const fiveSRouter = Router();
+
+fiveSRouter.use(authenticate);
+
+fiveSRouter.get(
+  '/audits/:projectId',
+  requireProjectRole(viewerRoles),
+  async (req: AuthenticatedRequest, res) => {
+    const { projectId } = req.params;
+    await enforceProjectAccess(req.user, projectId);
+    const audits = await fiveSAuditService.list(projectId);
+    res.json(audits);
+  }
+);
+
+fiveSRouter.post(
+  '/audits/:projectId',
+  requireProjectRole(editorRoles),
+  async (req: AuthenticatedRequest, res) => {
+    const { projectId } = req.params;
+    await enforceProjectAccess(req.user, projectId);
+    const created = await fiveSAuditService.create(
+      projectId,
+      req.body,
+      req.user!.id
+    );
+    res.status(201).json(created);
+  }
+);
+
+fiveSRouter.patch(
+  '/audits/:auditId',
+  requireProjectRole(editorRoles),
+  async (req: AuthenticatedRequest, res) => {
+    const { auditId } = req.params;
+    const projectId = await fiveSAuditService.getProjectId(auditId);
+    await enforceProjectAccess(req.user, projectId);
+    const updated = await fiveSAuditService.update(
+      auditId,
+      req.body,
+      req.user!.id
+    );
+    res.json(updated);
+  }
+);
+
+export { fiveSRouter };

--- a/web/src/features/projects/ProjectTabs.tsx
+++ b/web/src/features/projects/ProjectTabs.tsx
@@ -16,6 +16,7 @@ import FindingsTab from './tabs/FindingsTab';
 import WorkflowTab from './tabs/WorkflowTab';
 import GovernanceTab from './tabs/GovernanceTab';
 import InventoryTab from '../inventory/InventoryTab';
+import FiveSTab from './tabs/FiveSTab';
 
 interface TabComponentProps {
   projectId: string;
@@ -45,6 +46,7 @@ export const ProjectTabs: {
   { value: 'interviews', label: 'Entrevistas', component: InterviewsTab },
   { value: 'processes', label: 'Procesos', component: ProcessesTab },
   { value: 'systems', label: 'Sistemas', component: SystemsTab },
+  { value: 'fiveS', label: '5S', component: FiveSTab },
   { value: 'inventory', label: 'Maestro & Etiquetas', component: InventoryTab },
   { value: 'security', label: 'Seguridad', component: SecurityTab },
   { value: 'risks', label: 'Riesgos', component: RisksTab },

--- a/web/src/features/projects/tabs/FiveSTab.tsx
+++ b/web/src/features/projects/tabs/FiveSTab.tsx
@@ -1,0 +1,1001 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+import api from '../../../lib/api';
+
+type PhotoType = 'before' | 'after';
+
+type ActionStatus = 'todo' | 'in_progress' | 'done';
+
+interface FiveSAuditPhoto {
+  type: PhotoType;
+  url: string;
+  description?: string | null;
+}
+
+interface FiveSAuditAction {
+  description: string;
+  responsible?: string | null;
+  dueDate?: string | null;
+  status: ActionStatus;
+  notes?: string | null;
+}
+
+interface FiveSAudit {
+  id: string;
+  projectId: string;
+  area: string;
+  score: number;
+  auditDate: string;
+  notes?: string | null;
+  photos?: FiveSAuditPhoto[] | null;
+  actions?: FiveSAuditAction[] | null;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: { id: string; name: string | null } | null;
+}
+
+interface PhotoFormValue {
+  url: string;
+  description: string;
+}
+
+interface EditableAction {
+  description: string;
+  responsible: string;
+  dueDate: string;
+  status: ActionStatus;
+  notes: string;
+}
+
+interface FiveSTabProps {
+  projectId: string;
+}
+
+const statusOptions: { value: ActionStatus; label: string }[] = [
+  { value: 'todo', label: 'Pendiente' },
+  { value: 'in_progress', label: 'En seguimiento' },
+  { value: 'done', label: 'Completada' },
+];
+
+const defaultPhoto: PhotoFormValue = { url: '', description: '' };
+const defaultAction: EditableAction = {
+  description: '',
+  responsible: '',
+  dueDate: '',
+  status: 'todo',
+  notes: '',
+};
+
+const isPhoto = (value: unknown): value is FiveSAuditPhoto => {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  const type = record.type;
+  const url = record.url;
+  return (
+    (type === 'before' || type === 'after') &&
+    typeof url === 'string' &&
+    url.trim().length > 0
+  );
+};
+
+const isAction = (value: unknown): value is FiveSAuditAction => {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  const description = record.description;
+  const status = record.status;
+  return (
+    typeof description === 'string' &&
+    description.trim().length > 0 &&
+    (status === 'todo' || status === 'in_progress' || status === 'done')
+  );
+};
+
+const toDateInputValue = (value: string | undefined | null) => {
+  if (!value) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toISOString().slice(0, 10);
+};
+
+const formatDisplayDate = (value: string | undefined | null) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString('es-ES');
+};
+
+const formatNumber = (value: number | undefined | null) => {
+  if (value === undefined || value === null) return '—';
+  return Number(value).toFixed(1);
+};
+
+const FiveSTab = ({ projectId }: FiveSTabProps) => {
+  const [audits, setAudits] = useState<FiveSAudit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [area, setArea] = useState('');
+  const [score, setScore] = useState('3');
+  const [auditDate, setAuditDate] = useState(() =>
+    new Date().toISOString().slice(0, 10)
+  );
+  const [notes, setNotes] = useState('');
+  const [beforePhotos, setBeforePhotos] = useState<PhotoFormValue[]>([
+    { ...defaultPhoto },
+  ]);
+  const [afterPhotos, setAfterPhotos] = useState<PhotoFormValue[]>([
+    { ...defaultPhoto },
+  ]);
+  const [actions, setActions] = useState<EditableAction[]>([
+    { ...defaultAction },
+  ]);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formSuccess, setFormSuccess] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [actionDrafts, setActionDrafts] = useState<
+    Record<string, EditableAction[]>
+  >({});
+  const [noteDrafts, setNoteDrafts] = useState<Record<string, string>>({});
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const [updateSuccess, setUpdateSuccess] = useState<string | null>(null);
+  const [savingAuditId, setSavingAuditId] = useState<string | null>(null);
+
+  const resetForm = () => {
+    setArea('');
+    setScore('3');
+    setAuditDate(new Date().toISOString().slice(0, 10));
+    setNotes('');
+    setBeforePhotos([{ ...defaultPhoto }]);
+    setAfterPhotos([{ ...defaultPhoto }]);
+    setActions([{ ...defaultAction }]);
+  };
+
+  const mapAudit = (raw: FiveSAudit): FiveSAudit => ({
+    ...raw,
+    photos: Array.isArray(raw.photos)
+      ? raw.photos.filter((item) => isPhoto(item))
+      : [],
+    actions: Array.isArray(raw.actions)
+      ? raw.actions.filter((item) => isAction(item))
+      : [],
+  });
+
+  const fetchAudits = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.get<FiveSAudit[]>(
+        `/fiveS/audits/${projectId}`
+      );
+      const raw = Array.isArray(response.data) ? response.data : [];
+      setAudits(raw.map(mapAudit));
+    } catch (err) {
+      console.error('No se pudieron cargar las auditorías 5S', err);
+      setError('No se pudieron cargar las auditorías registradas.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAudits();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
+
+  useEffect(() => {
+    setActionDrafts(
+      audits.reduce<Record<string, EditableAction[]>>((acc, audit) => {
+        acc[audit.id] = (audit.actions ?? []).map((action) => ({
+          description: action.description,
+          responsible: action.responsible ?? '',
+          dueDate: toDateInputValue(action.dueDate),
+          status: action.status,
+          notes: action.notes ?? '',
+        }));
+        if (acc[audit.id].length === 0) {
+          acc[audit.id] = [{ ...defaultAction }];
+        }
+        return acc;
+      }, {})
+    );
+    setNoteDrafts(
+      audits.reduce<Record<string, string>>((acc, audit) => {
+        acc[audit.id] = audit.notes ?? '';
+        return acc;
+      }, {})
+    );
+  }, [audits]);
+
+  const combinedPhotos = useMemo(() => {
+    const make = (items: PhotoFormValue[], type: PhotoType) =>
+      items
+        .map((photo) => ({
+          type,
+          url: photo.url.trim(),
+          description: photo.description.trim(),
+        }))
+        .filter((photo) => photo.url.length > 0)
+        .map((photo) => ({
+          ...photo,
+          description:
+            photo.description.length > 0 ? photo.description : undefined,
+        }));
+
+    return {
+      before: make(beforePhotos, 'before'),
+      after: make(afterPhotos, 'after'),
+    };
+  }, [beforePhotos, afterPhotos]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+    setFormSuccess(null);
+
+    if (!area.trim()) {
+      setFormError('Debes indicar el área evaluada.');
+      return;
+    }
+
+    const numericScore = Number(score);
+    if (Number.isNaN(numericScore)) {
+      setFormError('La puntuación debe ser un número.');
+      return;
+    }
+
+    const payload = {
+      area: area.trim(),
+      score: numericScore,
+      auditDate,
+      notes: notes.trim() ? notes.trim() : undefined,
+      photos: [...combinedPhotos.before, ...combinedPhotos.after],
+      actions: actions
+        .map((action) => ({
+          ...action,
+          description: action.description.trim(),
+          responsible: action.responsible.trim(),
+          dueDate: action.dueDate.trim(),
+          notes: action.notes.trim(),
+        }))
+        .filter((action) => action.description.length > 0)
+        .map((action) => ({
+          description: action.description,
+          responsible:
+            action.responsible.length > 0 ? action.responsible : undefined,
+          dueDate: action.dueDate.length > 0 ? action.dueDate : undefined,
+          status: action.status,
+          notes: action.notes.length > 0 ? action.notes : undefined,
+        })),
+    };
+
+    setSubmitting(true);
+    try {
+      await api.post(`/fiveS/audits/${projectId}`, payload);
+      setFormSuccess('Auditoría 5S registrada correctamente.');
+      resetForm();
+      await fetchAudits();
+    } catch (err) {
+      console.error('No se pudo registrar la auditoría 5S', err);
+      setFormError(
+        'No se pudo registrar la auditoría. Revisa los datos e inténtalo nuevamente.'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handlePhotoChange = (
+    type: PhotoType,
+    index: number,
+    field: keyof PhotoFormValue,
+    value: string
+  ) => {
+    const updater = type === 'before' ? setBeforePhotos : setAfterPhotos;
+    updater((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], [field]: value };
+      return next;
+    });
+  };
+
+  const handleAddPhoto = (type: PhotoType) => {
+    const updater = type === 'before' ? setBeforePhotos : setAfterPhotos;
+    updater((prev) => [...prev, { ...defaultPhoto }]);
+  };
+
+  const handleRemovePhoto = (type: PhotoType, index: number) => {
+    const updater = type === 'before' ? setBeforePhotos : setAfterPhotos;
+    updater((prev) => {
+      if (prev.length === 1) return prev;
+      return prev.filter((_, idx) => idx !== index);
+    });
+  };
+
+  const handleActionChange = <K extends keyof EditableAction>(
+    index: number,
+    field: K,
+    value: EditableAction[K]
+  ) => {
+    setActions((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], [field]: value };
+      return next;
+    });
+  };
+
+  const handleAddAction = () => {
+    setActions((prev) => [...prev, { ...defaultAction }]);
+  };
+
+  const handleRemoveAction = (index: number) => {
+    setActions((prev) => {
+      if (prev.length === 1) return prev;
+      return prev.filter((_, idx) => idx !== index);
+    });
+  };
+
+  const handleDraftChange = <K extends keyof EditableAction>(
+    auditId: string,
+    index: number,
+    field: K,
+    value: EditableAction[K]
+  ) => {
+    setActionDrafts((prev) => {
+      const current = prev[auditId] ?? [{ ...defaultAction }];
+      const next = [...current];
+      next[index] = { ...next[index], [field]: value };
+      return { ...prev, [auditId]: next };
+    });
+  };
+
+  const handleAddDraftAction = (auditId: string) => {
+    setActionDrafts((prev) => {
+      const current = prev[auditId] ?? [];
+      return { ...prev, [auditId]: [...current, { ...defaultAction }] };
+    });
+  };
+
+  const handleRemoveDraftAction = (auditId: string, index: number) => {
+    setActionDrafts((prev) => {
+      const current = prev[auditId] ?? [];
+      if (current.length <= 1) return prev;
+      return {
+        ...prev,
+        [auditId]: current.filter((_, idx) => idx !== index),
+      };
+    });
+  };
+
+  const handleNoteDraftChange = (auditId: string, value: string) => {
+    setNoteDrafts((prev) => ({ ...prev, [auditId]: value }));
+  };
+
+  const handleSaveFollowUp = async (auditId: string) => {
+    const drafts = actionDrafts[auditId] ?? [];
+    const sanitizedActions = drafts
+      .map((action) => ({
+        description: action.description.trim(),
+        responsible: action.responsible.trim(),
+        dueDate: action.dueDate.trim(),
+        status: action.status,
+        notes: action.notes.trim(),
+      }))
+      .filter((action) => action.description.length > 0)
+      .map((action) => ({
+        description: action.description,
+        responsible:
+          action.responsible.length > 0 ? action.responsible : undefined,
+        dueDate: action.dueDate.length > 0 ? action.dueDate : undefined,
+        status: action.status,
+        notes: action.notes.length > 0 ? action.notes : undefined,
+      }));
+
+    const payload: Record<string, unknown> = { actions: sanitizedActions };
+    const note = noteDrafts[auditId]?.trim() ?? '';
+    if (note.length > 0 || noteDrafts[auditId] === '') {
+      payload.notes = note.length > 0 ? note : null;
+    }
+
+    setSavingAuditId(auditId);
+    setUpdateError(null);
+    setUpdateSuccess(null);
+    try {
+      await api.patch(`/fiveS/audits/${auditId}`, payload);
+      setUpdateSuccess('Seguimiento actualizado correctamente.');
+      await fetchAudits();
+    } catch (err) {
+      console.error('No se pudo actualizar el seguimiento 5S', err);
+      setUpdateError('No se pudo actualizar el seguimiento de acciones.');
+    } finally {
+      setSavingAuditId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">
+          Registrar nueva auditoría 5S
+        </h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Documenta el estado actual del área, carga evidencia fotográfica
+          antes/después y define las acciones correctivas.
+        </p>
+        <form className="mt-4 space-y-6" onSubmit={handleSubmit}>
+          <div className="grid gap-4 md:grid-cols-3">
+            <label className="flex flex-col text-sm font-medium text-slate-700">
+              Área evaluada
+              <input
+                type="text"
+                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                value={area}
+                onChange={(event) => setArea(event.target.value)}
+                placeholder="Ej. Andén de recepción"
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700">
+              Puntuación (0 a 5)
+              <input
+                type="number"
+                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                min={0}
+                max={5}
+                step={0.1}
+                value={score}
+                onChange={(event) => setScore(event.target.value)}
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700">
+              Fecha de auditoría
+              <input
+                type="date"
+                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                value={auditDate}
+                onChange={(event) => setAuditDate(event.target.value)}
+                required
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col text-sm font-medium text-slate-700">
+            Observaciones generales
+            <textarea
+              className="mt-1 min-h-[80px] rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              placeholder="Hallazgos relevantes, oportunidades o acuerdos principales"
+            />
+          </label>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {(['before', 'after'] as PhotoType[]).map((type) => {
+              const items = type === 'before' ? beforePhotos : afterPhotos;
+              return (
+                <div
+                  key={type}
+                  className="rounded-md border border-dashed border-slate-300 p-4"
+                >
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-semibold text-slate-800">
+                      Fotos {type === 'before' ? 'antes' : 'después'}
+                    </h3>
+                    <button
+                      type="button"
+                      className="text-sm font-medium text-sky-600 hover:text-sky-700"
+                      onClick={() => handleAddPhoto(type)}
+                    >
+                      Agregar foto
+                    </button>
+                  </div>
+                  <div className="mt-3 space-y-3">
+                    {items.map((photo, index) => (
+                      <div
+                        key={`${type}-${index}`}
+                        className="rounded-md border border-slate-200 p-3"
+                      >
+                        <div className="flex flex-col gap-2">
+                          <input
+                            type="url"
+                            className="rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                            placeholder="URL de la imagen"
+                            value={photo.url}
+                            onChange={(event) =>
+                              handlePhotoChange(
+                                type,
+                                index,
+                                'url',
+                                event.target.value
+                              )
+                            }
+                            required={false}
+                          />
+                          <input
+                            type="text"
+                            className="rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                            placeholder="Descripción opcional"
+                            value={photo.description}
+                            onChange={(event) =>
+                              handlePhotoChange(
+                                type,
+                                index,
+                                'description',
+                                event.target.value
+                              )
+                            }
+                          />
+                          {items.length > 1 && (
+                            <button
+                              type="button"
+                              className="self-start text-xs font-medium text-rose-600 hover:text-rose-700"
+                              onClick={() => handleRemovePhoto(type, index)}
+                            >
+                              Quitar
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="rounded-md border border-dashed border-slate-300 p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-slate-800">
+                Acciones correctivas
+              </h3>
+              <button
+                type="button"
+                className="text-sm font-medium text-sky-600 hover:text-sky-700"
+                onClick={handleAddAction}
+              >
+                Agregar acción
+              </button>
+            </div>
+            <div className="mt-3 space-y-4">
+              {actions.map((action, index) => (
+                <div
+                  key={`new-action-${index}`}
+                  className="rounded-md border border-slate-200 p-3"
+                >
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <label className="flex flex-col text-xs font-medium text-slate-600">
+                      Descripción
+                      <textarea
+                        className="mt-1 min-h-[60px] rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                        value={action.description}
+                        onChange={(event) =>
+                          handleActionChange(
+                            index,
+                            'description',
+                            event.target.value
+                          )
+                        }
+                        placeholder="Acción a realizar"
+                        required
+                      />
+                    </label>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <label className="flex flex-col text-xs font-medium text-slate-600">
+                        Responsable
+                        <input
+                          type="text"
+                          className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                          value={action.responsible}
+                          onChange={(event) =>
+                            handleActionChange(
+                              index,
+                              'responsible',
+                              event.target.value
+                            )
+                          }
+                          placeholder="Nombre o rol"
+                        />
+                      </label>
+                      <label className="flex flex-col text-xs font-medium text-slate-600">
+                        Fecha compromiso
+                        <input
+                          type="date"
+                          className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                          value={action.dueDate}
+                          onChange={(event) =>
+                            handleActionChange(
+                              index,
+                              'dueDate',
+                              event.target.value
+                            )
+                          }
+                        />
+                      </label>
+                    </div>
+                    <label className="flex flex-col text-xs font-medium text-slate-600">
+                      Comentarios
+                      <input
+                        type="text"
+                        className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                        value={action.notes}
+                        onChange={(event) =>
+                          handleActionChange(index, 'notes', event.target.value)
+                        }
+                        placeholder="Notas de seguimiento"
+                      />
+                    </label>
+                    <label className="flex flex-col text-xs font-medium text-slate-600">
+                      Estado
+                      <select
+                        className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                        value={action.status}
+                        onChange={(event) =>
+                          handleActionChange(
+                            index,
+                            'status',
+                            event.target.value as ActionStatus
+                          )
+                        }
+                      >
+                        {statusOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+                  {actions.length > 1 && (
+                    <button
+                      type="button"
+                      className="mt-3 text-xs font-medium text-rose-600 hover:text-rose-700"
+                      onClick={() => handleRemoveAction(index)}
+                    >
+                      Quitar acción
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {formError && <p className="text-sm text-rose-600">{formError}</p>}
+          {formSuccess && (
+            <p className="text-sm text-emerald-600">{formSuccess}</p>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-70"
+              disabled={submitting}
+            >
+              {submitting ? 'Registrando…' : 'Registrar auditoría'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Historial de auditorías
+            </h2>
+            <p className="text-sm text-slate-500">
+              Consulta auditorías previas, evidencia fotográfica y actualiza el
+              estado de las acciones.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="self-start rounded-md border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400"
+            onClick={fetchAudits}
+          >
+            Refrescar
+          </button>
+        </div>
+
+        <div className="mt-4 space-y-5">
+          {loading && (
+            <p className="text-sm text-slate-500">Cargando auditorías…</p>
+          )}
+          {error && <p className="text-sm text-rose-600">{error}</p>}
+          {!loading && !error && audits.length === 0 && (
+            <p className="text-sm text-slate-500">
+              Aún no existen auditorías registradas para este proyecto.
+            </p>
+          )}
+
+          {!loading &&
+            !error &&
+            audits.map((audit) => {
+              const before = (audit.photos ?? []).filter(
+                (photo) => photo.type === 'before'
+              );
+              const after = (audit.photos ?? []).filter(
+                (photo) => photo.type === 'after'
+              );
+              const drafts = actionDrafts[audit.id] ?? [{ ...defaultAction }];
+              const noteDraft = noteDrafts[audit.id] ?? '';
+              return (
+                <article
+                  key={audit.id}
+                  className="rounded-md border border-slate-200 p-5"
+                >
+                  <div className="flex flex-col gap-2 border-b border-slate-200 pb-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h3 className="text-base font-semibold text-slate-900">
+                        {audit.area}
+                      </h3>
+                      <div className="mt-1 flex flex-wrap gap-4 text-sm text-slate-600">
+                        <span>Puntuación: {formatNumber(audit.score)}</span>
+                        <span>Fecha: {formatDisplayDate(audit.auditDate)}</span>
+                        <span>
+                          Registrado: {formatDisplayDate(audit.createdAt)}
+                        </span>
+                      </div>
+                    </div>
+                    {audit.createdBy?.name && (
+                      <span className="text-sm text-slate-500">
+                        Registrado por {audit.createdBy.name}
+                      </span>
+                    )}
+                  </div>
+
+                  {(before.length > 0 || after.length > 0) && (
+                    <div className="mt-4 grid gap-4 md:grid-cols-2">
+                      <div>
+                        <h4 className="text-sm font-semibold text-slate-800">
+                          Antes
+                        </h4>
+                        <div className="mt-2 space-y-3">
+                          {before.length === 0 && (
+                            <p className="text-xs text-slate-500">
+                              Sin evidencia registrada.
+                            </p>
+                          )}
+                          {before.map((photo, index) => (
+                            <div
+                              key={`before-${audit.id}-${index}`}
+                              className="space-y-2 rounded-md border border-slate-200 p-3"
+                            >
+                              <img
+                                src={photo.url}
+                                alt={`Foto antes ${index + 1} - ${audit.area}`}
+                                className="h-40 w-full rounded-md object-cover"
+                                loading="lazy"
+                              />
+                              {photo.description && (
+                                <p className="text-xs text-slate-600">
+                                  {photo.description}
+                                </p>
+                              )}
+                              <a
+                                href={photo.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="block text-xs font-medium text-sky-600 hover:text-sky-700"
+                              >
+                                Abrir imagen
+                              </a>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <h4 className="text-sm font-semibold text-slate-800">
+                          Después
+                        </h4>
+                        <div className="mt-2 space-y-3">
+                          {after.length === 0 && (
+                            <p className="text-xs text-slate-500">
+                              Sin evidencia registrada.
+                            </p>
+                          )}
+                          {after.map((photo, index) => (
+                            <div
+                              key={`after-${audit.id}-${index}`}
+                              className="space-y-2 rounded-md border border-slate-200 p-3"
+                            >
+                              <img
+                                src={photo.url}
+                                alt={`Foto después ${index + 1} - ${audit.area}`}
+                                className="h-40 w-full rounded-md object-cover"
+                                loading="lazy"
+                              />
+                              {photo.description && (
+                                <p className="text-xs text-slate-600">
+                                  {photo.description}
+                                </p>
+                              )}
+                              <a
+                                href={photo.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="block text-xs font-medium text-sky-600 hover:text-sky-700"
+                              >
+                                Abrir imagen
+                              </a>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="mt-4 space-y-3">
+                    <h4 className="text-sm font-semibold text-slate-800">
+                      Seguimiento de acciones
+                    </h4>
+                    <div className="space-y-4">
+                      {drafts.map((action, index) => (
+                        <div
+                          key={`draft-${audit.id}-${index}`}
+                          className="rounded-md border border-slate-200 p-3"
+                        >
+                          <div className="grid gap-3 md:grid-cols-2">
+                            <label className="flex flex-col text-xs font-medium text-slate-600">
+                              Descripción
+                              <textarea
+                                className="mt-1 min-h-[60px] rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                                value={action.description}
+                                onChange={(event) =>
+                                  handleDraftChange(
+                                    audit.id,
+                                    index,
+                                    'description',
+                                    event.target.value
+                                  )
+                                }
+                              />
+                            </label>
+                            <div className="grid gap-3 sm:grid-cols-2">
+                              <label className="flex flex-col text-xs font-medium text-slate-600">
+                                Responsable
+                                <input
+                                  type="text"
+                                  className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                                  value={action.responsible}
+                                  onChange={(event) =>
+                                    handleDraftChange(
+                                      audit.id,
+                                      index,
+                                      'responsible',
+                                      event.target.value
+                                    )
+                                  }
+                                />
+                              </label>
+                              <label className="flex flex-col text-xs font-medium text-slate-600">
+                                Fecha compromiso
+                                <input
+                                  type="date"
+                                  className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                                  value={action.dueDate}
+                                  onChange={(event) =>
+                                    handleDraftChange(
+                                      audit.id,
+                                      index,
+                                      'dueDate',
+                                      event.target.value
+                                    )
+                                  }
+                                />
+                              </label>
+                            </div>
+                            <label className="flex flex-col text-xs font-medium text-slate-600">
+                              Comentarios
+                              <input
+                                type="text"
+                                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                                value={action.notes}
+                                onChange={(event) =>
+                                  handleDraftChange(
+                                    audit.id,
+                                    index,
+                                    'notes',
+                                    event.target.value
+                                  )
+                                }
+                              />
+                            </label>
+                            <label className="flex flex-col text-xs font-medium text-slate-600">
+                              Estado
+                              <select
+                                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                                value={action.status}
+                                onChange={(event) =>
+                                  handleDraftChange(
+                                    audit.id,
+                                    index,
+                                    'status',
+                                    event.target.value as ActionStatus
+                                  )
+                                }
+                              >
+                                {statusOptions.map((option) => (
+                                  <option
+                                    key={option.value}
+                                    value={option.value}
+                                  >
+                                    {option.label}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                          </div>
+                          {(drafts.length > 1 ||
+                            (drafts.length === 1 && drafts[0].description)) && (
+                            <button
+                              type="button"
+                              className="mt-3 text-xs font-medium text-rose-600 hover:text-rose-700"
+                              onClick={() =>
+                                handleRemoveDraftAction(audit.id, index)
+                              }
+                            >
+                              Quitar
+                            </button>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                    <button
+                      type="button"
+                      className="text-sm font-medium text-sky-600 hover:text-sky-700"
+                      onClick={() => handleAddDraftAction(audit.id)}
+                    >
+                      Agregar acción de seguimiento
+                    </button>
+                    <label className="mt-2 flex flex-col text-xs font-medium text-slate-600">
+                      Notas de seguimiento
+                      <textarea
+                        className="mt-1 min-h-[60px] rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                        value={noteDraft}
+                        onChange={(event) =>
+                          handleNoteDraftChange(audit.id, event.target.value)
+                        }
+                        placeholder="Resumen de avances o acuerdos"
+                      />
+                    </label>
+                    <div className="flex items-center justify-end gap-3">
+                      {savingAuditId === audit.id && (
+                        <span className="text-sm text-slate-500">
+                          Guardando…
+                        </span>
+                      )}
+                      <button
+                        type="button"
+                        className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-70"
+                        onClick={() => handleSaveFollowUp(audit.id)}
+                        disabled={savingAuditId === audit.id}
+                      >
+                        Guardar seguimiento
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+        </div>
+
+        {updateError && (
+          <p className="mt-4 text-sm text-rose-600">{updateError}</p>
+        )}
+        {updateSuccess && (
+          <p className="mt-4 text-sm text-emerald-600">{updateSuccess}</p>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default FiveSTab;

--- a/web/src/pages/ProjectPage.tsx
+++ b/web/src/pages/ProjectPage.tsx
@@ -26,6 +26,7 @@ const TAB_TO_PATH: Record<string, string> = {
   interviews: 'interviews',
   processes: 'procesos',
   systems: 'systems',
+  fiveS: '5s',
   inventory: 'inventory',
   security: 'security',
   risks: 'risks',


### PR DESCRIPTION
## Summary
- add the FiveS_Audit Prisma model, migration and router wiring
- expose service and endpoints to create, list and update 5S audits with evidence and corrective actions
- add a dedicated 5S project tab to capture audits, photos and follow-up notes from the web app

## Testing
- npm run lint --prefix api *(fails: existing lint parsing errors in repository)*
- npm run lint --prefix web *(fails: existing prettier/eslint issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68def11efc308331a09635e26a2fe063