### PR TITLE
feat: add hse safety management module

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -109,6 +109,21 @@ paths:
       summary: Actualiza registro
     delete:
       summary: Elimina registro
+  /hse/checks/{projectId}:
+    get:
+      summary: Lista chequeos HSE
+    post:
+      summary: Registra un chequeo HSE
+  /hse/ppe/{projectId}:
+    get:
+      summary: Lista asignaciones de EPP
+    post:
+      summary: Registra asignación de EPP
+  /hse/incidents/{projectId}:
+    get:
+      summary: Lista incidentes HSE
+    post:
+      summary: Reporta un incidente HSE
   /receptions/{projectId}:
     get:
       summary: Lista recepciones

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -66,6 +66,19 @@ enum InventoryCountStatus {
   closed
 }
 
+enum HSECheckType {
+  induccion
+  checklist
+  inspeccion
+}
+
+enum IncidentSeverity {
+  baja
+  media
+  alta
+  critica
+}
+
 model Project {
   id                     String                  @id @default(cuid())
   companyId              String
@@ -116,6 +129,9 @@ model Project {
   surveyLinks            SurveyLink[]
   surveys                Survey[]
   interviews             Interview[]
+  hseChecks              HSECheck[]
+  ppeAssignments         PPEAssign[]
+  incidents              Incident[]
   createdAt              DateTime                @default(now())
   updatedAt              DateTime                @updatedAt
 
@@ -141,11 +157,76 @@ model User {
   installedLabels       BarcodeLabel[]          @relation("BarcodeInstalledBy")
   inventoryTasks        InventoryTask[]         @relation("InventoryTaskAssignedTo")
   fiveSAudits           FiveSAudit[]            @relation("FiveSAuditCreatedBy")
-  createdAt             DateTime                @default(now())
-  updatedAt             DateTime                @updatedAt
   QuestionnaireTemplate QuestionnaireTemplate[]
   SurveyLink            SurveyLink[]
   Interview             Interview[]
+  hseChecksCreated      HSECheck[]             @relation("HSECheckCreatedBy")
+  ppeAssignmentsCreated PPEAssign[]            @relation("PPEAssignCreatedBy")
+  incidentsReported     Incident[]             @relation("IncidentReportedBy")
+  createdAt             DateTime                @default(now())
+  updatedAt             DateTime                @updatedAt
+}
+
+model HSECheck {
+  id           String       @id @default(cuid())
+  projectId    String
+  project      Project      @relation(fields: [projectId], references: [id])
+  type         HSECheckType
+  title        String
+  conductedBy  String?
+  location     String?
+  notes        String?
+  items        Json         @default("[]")
+  evidence     Json         @default("[]")
+  performedAt  DateTime     @default(now())
+  createdById  String?
+  createdBy    User?        @relation("HSECheckCreatedBy", fields: [createdById], references: [id])
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+
+  @@index([projectId])
+  @@map("HSE_Check")
+}
+
+model PPEAssign {
+  id           String   @id @default(cuid())
+  projectId    String
+  project      Project  @relation(fields: [projectId], references: [id])
+  personName   String
+  role         String?
+  assignedAt   DateTime @default(now())
+  deliveredBy  String?
+  notes        String?
+  items        Json     @default("[]")
+  evidence     Json     @default("[]")
+  createdById  String?
+  createdBy    User?    @relation("PPEAssignCreatedBy", fields: [createdById], references: [id])
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([projectId])
+  @@map("PPE_Assign")
+}
+
+model Incident {
+  id                String           @id @default(cuid())
+  projectId         String
+  project           Project          @relation(fields: [projectId], references: [id])
+  title             String
+  severity          IncidentSeverity @default(baja)
+  description       String?
+  reportedBy        String?
+  occurredAt        DateTime         @default(now())
+  location          String?
+  immediateActions  String?
+  correctiveActions String?
+  photos            Json             @default("[]")
+  createdById       String?
+  createdBy         User?            @relation("IncidentReportedBy", fields: [createdById], references: [id])
+  createdAt         DateTime         @default(now())
+  updatedAt         DateTime         @updatedAt
+
+  @@index([projectId])
 }
 
 model FiveSAudit {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -31,6 +31,7 @@ import { reportRouter } from './modules/reports/report.router.js';
 import { interviewRouter } from './modules/interviews/interview.router.js';
 import { inventoryRouter } from './modules/inventory/inventory.router.js';
 import { fiveSRouter } from './modules/fiveS/five-s.router.js';
+import { hseRouter } from './modules/hse/hse.router.js';
 
 const appRouter = Router();
 
@@ -65,5 +66,6 @@ appRouter.use('/reports', reportRouter);
 appRouter.use('/interviews', interviewRouter);
 appRouter.use('/inventory', inventoryRouter);
 appRouter.use('/fiveS', fiveSRouter);
+appRouter.use('/hse', hseRouter);
 
 export { appRouter };

--- a/api/src/modules/hse/hse.router.ts
+++ b/api/src/modules/hse/hse.router.ts
@@ -1,0 +1,96 @@
+import { Router } from 'express';
+
+import {
+  authenticate,
+  requireProjectRole,
+  type AuthenticatedRequest,
+} from '../../core/middleware/auth.js';
+import { enforceProjectAccess } from '../../core/security/enforce-project-access.js';
+import { hseService } from './hse.service.js';
+
+const viewerRoles = ['ConsultorLider', 'Auditor', 'SponsorPM', 'Invitado'];
+const editorRoles = ['ConsultorLider', 'Auditor'];
+
+const hseRouter = Router();
+
+hseRouter.use(authenticate);
+
+hseRouter.get(
+  '/checks/:projectId',
+  requireProjectRole(viewerRoles),
+  async (req: AuthenticatedRequest, res) => {
+    const { projectId } = req.params;
+    await enforceProjectAccess(req.user, projectId);
+    const checks = await hseService.listChecks(projectId);
+    res.json(checks);
+  }
+);
+
+hseRouter.post(
+  '/checks/:projectId',
+  requireProjectRole(editorRoles),
+  async (req: AuthenticatedRequest, res) => {
+    const { projectId } = req.params;
+    await enforceProjectAccess(req.user, projectId);
+    const created = await hseService.createCheck(
+      projectId,
+      req.body,
+      req.user!.id
+    );
+    res.status(201).json(created);
+  }
+);
+
+hseRouter.get(
+  '/ppe/:projectId',
+  requireProjectRole(viewerRoles),
+  async (req: AuthenticatedRequest, res) => {
+    const { projectId } = req.params;
+    await enforceProjectAccess(req.user, projectId);
+    const assignments = await hseService.listAssignments(projectId);
+    res.json(assignments);
+  }
+);
+
+hseRouter.post(
+  '/ppe/:projectId',
+  requireProjectRole(editorRoles),
+  async (req: AuthenticatedRequest, res) => {
+    const { projectId } = req.params;
+    await enforceProjectAccess(req.user, projectId);
+    const created = await hseService.createAssignment(
+      projectId,
+      req.body,
+      req.user!.id
+    );
+    res.status(201).json(created);
+  }
+);
+
+hseRouter.get(
+  '/incidents/:projectId',
+  requireProjectRole(viewerRoles),
+  async (req: AuthenticatedRequest, res) => {
+    const { projectId } = req.params;
+    await enforceProjectAccess(req.user, projectId);
+    const incidents = await hseService.listIncidents(projectId);
+    res.json(incidents);
+  }
+);
+
+hseRouter.post(
+  '/incidents/:projectId',
+  requireProjectRole(editorRoles),
+  async (req: AuthenticatedRequest, res) => {
+    const { projectId } = req.params;
+    await enforceProjectAccess(req.user, projectId);
+    const created = await hseService.createIncident(
+      projectId,
+      req.body,
+      req.user!.id
+    );
+    res.status(201).json(created);
+  }
+);
+
+export { hseRouter };

--- a/api/src/modules/hse/hse.service.ts
+++ b/api/src/modules/hse/hse.service.ts
@@ -1,0 +1,244 @@
+import { Prisma } from '@prisma/client';
+import { z } from 'zod';
+
+import { prisma } from '../../core/config/db.js';
+import { auditService } from '../audit/audit.service.js';
+
+const optionalString = z
+  .string()
+  .trim()
+  .optional()
+  .transform((value) => (value && value.length > 0 ? value : undefined));
+
+const evidenceSchema = z.object({
+  url: z.string().trim().min(1, 'La URL de la evidencia es obligatoria'),
+  description: optionalString,
+});
+
+const checkItemSchema = z.object({
+  description: z
+    .string()
+    .trim()
+    .min(1, 'La descripción del ítem es obligatoria'),
+  status: z.enum(['ok', 'no_ok', 'na']).default('ok'),
+  notes: optionalString,
+});
+
+const createCheckSchema = z.object({
+  type: z.enum(['induccion', 'checklist', 'inspeccion']),
+  title: z.string().trim().min(1, 'El título es obligatorio'),
+  conductedBy: optionalString,
+  location: optionalString,
+  notes: optionalString,
+  items: z.array(checkItemSchema).default([]),
+  evidence: z.array(evidenceSchema).default([]),
+  performedAt: z.coerce.date().optional(),
+});
+
+const assignmentItemSchema = z.object({
+  item: z.string().trim().min(1, 'El nombre del EPP es obligatorio'),
+  quantity: z.coerce
+    .number()
+    .int()
+    .positive('La cantidad debe ser mayor a 0')
+    .optional(),
+  notes: optionalString,
+});
+
+const createPpeSchema = z.object({
+  personName: z
+    .string()
+    .trim()
+    .min(1, 'El nombre de la persona es obligatorio'),
+  role: optionalString,
+  deliveredBy: optionalString,
+  notes: optionalString,
+  assignedAt: z.coerce.date().optional(),
+  items: z
+    .array(assignmentItemSchema)
+    .min(1, 'Registra al menos un EPP entregado'),
+  evidence: z.array(evidenceSchema).default([]),
+});
+
+const createIncidentSchema = z.object({
+  title: z.string().trim().min(1, 'El título del incidente es obligatorio'),
+  severity: z.enum(['baja', 'media', 'alta', 'critica']).default('baja'),
+  description: optionalString,
+  reportedBy: optionalString,
+  occurredAt: z.coerce.date().optional(),
+  location: optionalString,
+  immediateActions: optionalString,
+  correctiveActions: optionalString,
+  photos: z.array(evidenceSchema).default([]),
+});
+
+const toJsonArray = (
+  value:
+    | z.infer<typeof evidenceSchema>[]
+    | z.infer<typeof checkItemSchema>[]
+    | z.infer<typeof assignmentItemSchema>[]
+) => value as unknown as Prisma.JsonArray;
+
+export const hseService = {
+  async listChecks(projectId: string) {
+    return prisma.hSECheck.findMany({
+      where: { projectId },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: [{ performedAt: 'desc' }, { createdAt: 'desc' }],
+    });
+  },
+
+  async createCheck(projectId: string, payload: unknown, userId: string) {
+    const data = createCheckSchema.parse(payload);
+
+    const created = await prisma.hSECheck.create({
+      data: {
+        projectId,
+        type: data.type,
+        title: data.title,
+        conductedBy: data.conductedBy ?? null,
+        location: data.location ?? null,
+        notes: data.notes ?? null,
+        items: toJsonArray(data.items),
+        evidence: toJsonArray(data.evidence),
+        performedAt: data.performedAt ?? new Date(),
+        createdById: userId,
+      },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    await auditService.record(
+      'HSE_Check',
+      created.id,
+      'CREATE',
+      userId,
+      projectId,
+      null,
+      created
+    );
+
+    return created;
+  },
+
+  async listAssignments(projectId: string) {
+    return prisma.pPEAssign.findMany({
+      where: { projectId },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: [{ assignedAt: 'desc' }, { createdAt: 'desc' }],
+    });
+  },
+
+  async createAssignment(projectId: string, payload: unknown, userId: string) {
+    const data = createPpeSchema.parse(payload);
+
+    const created = await prisma.pPEAssign.create({
+      data: {
+        projectId,
+        personName: data.personName,
+        role: data.role ?? null,
+        deliveredBy: data.deliveredBy ?? null,
+        notes: data.notes ?? null,
+        assignedAt: data.assignedAt ?? new Date(),
+        items: toJsonArray(data.items),
+        evidence: toJsonArray(data.evidence),
+        createdById: userId,
+      },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    await auditService.record(
+      'PPE_Assign',
+      created.id,
+      'CREATE',
+      userId,
+      projectId,
+      null,
+      created
+    );
+
+    return created;
+  },
+
+  async listIncidents(projectId: string) {
+    return prisma.incident.findMany({
+      where: { projectId },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: [{ occurredAt: 'desc' }, { createdAt: 'desc' }],
+    });
+  },
+
+  async createIncident(projectId: string, payload: unknown, userId: string) {
+    const data = createIncidentSchema.parse(payload);
+
+    const created = await prisma.incident.create({
+      data: {
+        projectId,
+        title: data.title,
+        severity: data.severity,
+        description: data.description ?? null,
+        reportedBy: data.reportedBy ?? null,
+        occurredAt: data.occurredAt ?? new Date(),
+        location: data.location ?? null,
+        immediateActions: data.immediateActions ?? null,
+        correctiveActions: data.correctiveActions ?? null,
+        photos: toJsonArray(data.photos),
+        createdById: userId,
+      },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    await auditService.record(
+      'Incident',
+      created.id,
+      'CREATE',
+      userId,
+      projectId,
+      null,
+      created
+    );
+
+    return created;
+  },
+};

--- a/web/src/features/projects/ProjectTabs.tsx
+++ b/web/src/features/projects/ProjectTabs.tsx
@@ -17,6 +17,7 @@ import WorkflowTab from './tabs/WorkflowTab';
 import GovernanceTab from './tabs/GovernanceTab';
 import InventoryTab from '../inventory/InventoryTab';
 import FiveSTab from './tabs/FiveSTab';
+import HseTab from './tabs/HseTab';
 
 interface TabComponentProps {
   projectId: string;
@@ -47,6 +48,7 @@ export const ProjectTabs: {
   { value: 'processes', label: 'Procesos', component: ProcessesTab },
   { value: 'systems', label: 'Sistemas', component: SystemsTab },
   { value: 'fiveS', label: '5S', component: FiveSTab },
+  { value: 'hse', label: 'HSE', component: HseTab },
   { value: 'inventory', label: 'Maestro & Etiquetas', component: InventoryTab },
   { value: 'security', label: 'Seguridad', component: SecurityTab },
   { value: 'risks', label: 'Riesgos', component: RisksTab },

--- a/web/src/features/projects/tabs/HseTab.tsx
+++ b/web/src/features/projects/tabs/HseTab.tsx
@@ -1,0 +1,1006 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import api from '../../../lib/api';
+import { useAuth } from '../../../hooks/useAuth';
+import { getErrorMessage } from '../../../lib/errors';
+
+interface Evidence {
+  url: string;
+  description?: string | null;
+}
+
+interface CheckItem {
+  description: string;
+  status?: 'ok' | 'no_ok' | 'na' | null;
+  notes?: string | null;
+}
+
+interface HseCheck {
+  id: string;
+  type: 'induccion' | 'checklist' | 'inspeccion';
+  title: string;
+  conductedBy?: string | null;
+  location?: string | null;
+  notes?: string | null;
+  items?: CheckItem[] | null;
+  evidence?: Evidence[] | null;
+  performedAt: string;
+  createdBy?: { id: string; name: string | null } | null;
+}
+
+interface PpeItem {
+  item: string;
+  quantity?: number | null;
+  notes?: string | null;
+}
+
+interface PpeAssignment {
+  id: string;
+  personName: string;
+  role?: string | null;
+  deliveredBy?: string | null;
+  notes?: string | null;
+  assignedAt: string;
+  items?: PpeItem[] | null;
+  evidence?: Evidence[] | null;
+  createdBy?: { id: string; name: string | null } | null;
+}
+
+interface Incident {
+  id: string;
+  title: string;
+  severity: 'baja' | 'media' | 'alta' | 'critica';
+  description?: string | null;
+  reportedBy?: string | null;
+  occurredAt: string;
+  location?: string | null;
+  immediateActions?: string | null;
+  correctiveActions?: string | null;
+  photos?: Evidence[] | null;
+  createdBy?: { id: string; name: string | null } | null;
+}
+
+interface HseTabProps {
+  projectId: string;
+}
+
+const checkTypeLabels: Record<HseCheck['type'], string> = {
+  induccion: 'Inducción',
+  checklist: 'Checklist',
+  inspeccion: 'Inspección',
+};
+
+const severityLabels: Record<Incident['severity'], string> = {
+  baja: 'Baja',
+  media: 'Media',
+  alta: 'Alta',
+  critica: 'Crítica',
+};
+
+const defaultCheckForm = {
+  type: 'induccion' as HseCheck['type'],
+  title: '',
+  conductedBy: '',
+  performedAt: '',
+  location: '',
+  notes: '',
+  itemsText: '',
+  evidenceText: '',
+};
+
+const defaultPpeForm = {
+  personName: '',
+  role: '',
+  deliveredBy: '',
+  assignedAt: '',
+  notes: '',
+  itemsText: '',
+  evidenceText: '',
+};
+
+const defaultIncidentForm = {
+  title: '',
+  severity: 'baja' as Incident['severity'],
+  description: '',
+  reportedBy: '',
+  occurredAt: '',
+  location: '',
+  immediateActions: '',
+  correctiveActions: '',
+  photosText: '',
+};
+
+const parseEvidence = (text: string): Evidence[] =>
+  text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [url, ...rest] = line.split('|');
+      const description = rest.join('|').trim();
+      return {
+        url: url.trim(),
+        description: description.length > 0 ? description : undefined,
+      };
+    });
+
+const parseCheckItems = (text: string): CheckItem[] =>
+  text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((description) => ({ description, status: 'ok' as const }));
+
+const parsePpeItems = (text: string): PpeItem[] =>
+  text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [item, qty, ...rest] = line.split('|');
+      const quantity = qty ? Number.parseInt(qty.trim(), 10) : undefined;
+      const notes = rest.join('|').trim();
+      return {
+        item: item.trim(),
+        quantity: Number.isNaN(quantity) ? undefined : quantity,
+        notes: notes.length > 0 ? notes : undefined,
+      };
+    });
+
+const formatDate = (value: string) => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString();
+};
+
+export default function HseTab({ projectId }: HseTabProps) {
+  const { role } = useAuth();
+  const canEdit = useMemo(() => ['admin', 'consultor'].includes(role), [role]);
+
+  const [checks, setChecks] = useState<HseCheck[]>([]);
+  const [ppeAssignments, setPpeAssignments] = useState<PpeAssignment[]>([]);
+  const [incidents, setIncidents] = useState<Incident[]>([]);
+
+  const [checkForm, setCheckForm] = useState(defaultCheckForm);
+  const [ppeForm, setPpeForm] = useState(defaultPpeForm);
+  const [incidentForm, setIncidentForm] = useState(defaultIncidentForm);
+
+  const [error, setError] = useState<string | null>(null);
+
+  const loadChecks = useCallback(async () => {
+    setError(null);
+    try {
+      const response = await api.get<HseCheck[]>(`/hse/checks/${projectId}`);
+      setChecks(Array.isArray(response.data) ? response.data : []);
+    } catch (err: unknown) {
+      setError(getErrorMessage(err, 'No se pudieron cargar los chequeos HSE'));
+    }
+  }, [projectId]);
+
+  const loadPpe = useCallback(async () => {
+    setError(null);
+    try {
+      const response = await api.get<PpeAssignment[]>(`/hse/ppe/${projectId}`);
+      setPpeAssignments(Array.isArray(response.data) ? response.data : []);
+    } catch (err: unknown) {
+      setError(
+        getErrorMessage(err, 'No se pudieron cargar las asignaciones de EPP')
+      );
+    }
+  }, [projectId]);
+
+  const loadIncidents = useCallback(async () => {
+    setError(null);
+    try {
+      const response = await api.get<Incident[]>(
+        `/hse/incidents/${projectId}`
+      );
+      setIncidents(Array.isArray(response.data) ? response.data : []);
+    } catch (err: unknown) {
+      setError(getErrorMessage(err, 'No se pudieron cargar los incidentes'));
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void loadChecks();
+    void loadPpe();
+    void loadIncidents();
+  }, [loadChecks, loadPpe, loadIncidents]);
+
+  const handleSubmitCheck = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+
+    try {
+      setError(null);
+      await api.post(`/hse/checks/${projectId}`, {
+        type: checkForm.type,
+        title: checkForm.title,
+        conductedBy: checkForm.conductedBy || undefined,
+        location: checkForm.location || undefined,
+        notes: checkForm.notes || undefined,
+        performedAt: checkForm.performedAt || undefined,
+        items: parseCheckItems(checkForm.itemsText),
+        evidence: parseEvidence(checkForm.evidenceText),
+      });
+      setCheckForm(defaultCheckForm);
+      await loadChecks();
+    } catch (err: unknown) {
+      setError(getErrorMessage(err, 'No se pudo registrar el chequeo HSE'));
+    }
+  };
+
+  const handleSubmitPpe = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+
+    try {
+      setError(null);
+      await api.post(`/hse/ppe/${projectId}`, {
+        personName: ppeForm.personName,
+        role: ppeForm.role || undefined,
+        deliveredBy: ppeForm.deliveredBy || undefined,
+        assignedAt: ppeForm.assignedAt || undefined,
+        notes: ppeForm.notes || undefined,
+        items: parsePpeItems(ppeForm.itemsText),
+        evidence: parseEvidence(ppeForm.evidenceText),
+      });
+      setPpeForm(defaultPpeForm);
+      await loadPpe();
+    } catch (err: unknown) {
+      setError(
+        getErrorMessage(err, 'No se pudo registrar la asignación de EPP')
+      );
+    }
+  };
+
+  const handleSubmitIncident = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canEdit) return;
+
+    try {
+      setError(null);
+      await api.post(`/hse/incidents/${projectId}`, {
+        title: incidentForm.title,
+        severity: incidentForm.severity,
+        description: incidentForm.description || undefined,
+        reportedBy: incidentForm.reportedBy || undefined,
+        occurredAt: incidentForm.occurredAt || undefined,
+        location: incidentForm.location || undefined,
+        immediateActions: incidentForm.immediateActions || undefined,
+        correctiveActions: incidentForm.correctiveActions || undefined,
+        photos: parseEvidence(incidentForm.photosText),
+      });
+      setIncidentForm(defaultIncidentForm);
+      await loadIncidents();
+    } catch (err: unknown) {
+      setError(getErrorMessage(err, 'No se pudo reportar el incidente'));
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {error ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">
+              Chequeos e inducciones HSE
+            </h2>
+            <p className="text-sm text-slate-500">
+              Documenta inducciones, checklists y evidencias fotográficas.
+            </p>
+          </div>
+        </div>
+
+        {canEdit ? (
+          <form className="mb-6 grid gap-4 md:grid-cols-2" onSubmit={handleSubmitCheck}>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Tipo de registro
+              </label>
+              <select
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={checkForm.type}
+                onChange={(event) =>
+                  setCheckForm((prev) => ({
+                    ...prev,
+                    type: event.target.value as HseCheck['type'],
+                  }))
+                }
+              >
+                <option value="induccion">Inducción</option>
+                <option value="checklist">Checklist</option>
+                <option value="inspeccion">Inspección</option>
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Fecha de ejecución
+              </label>
+              <input
+                type="date"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={checkForm.performedAt}
+                onChange={(event) =>
+                  setCheckForm((prev) => ({
+                    ...prev,
+                    performedAt: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Título o actividad
+              </label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={checkForm.title}
+                onChange={(event) =>
+                  setCheckForm((prev) => ({
+                    ...prev,
+                    title: event.target.value,
+                  }))
+                }
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Responsable / Facilitador
+              </label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={checkForm.conductedBy}
+                onChange={(event) =>
+                  setCheckForm((prev) => ({
+                    ...prev,
+                    conductedBy: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">Ubicación</label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={checkForm.location}
+                onChange={(event) =>
+                  setCheckForm((prev) => ({
+                    ...prev,
+                    location: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Ítems del checklist (uno por línea)
+              </label>
+              <textarea
+                className="min-h-[80px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                placeholder="Ingreso a planta\nUso de EPP\nBriefing de riesgos"
+                value={checkForm.itemsText}
+                onChange={(event) =>
+                  setCheckForm((prev) => ({
+                    ...prev,
+                    itemsText: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Notas generales
+              </label>
+              <textarea
+                className="min-h-[60px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={checkForm.notes}
+                onChange={(event) =>
+                  setCheckForm((prev) => ({
+                    ...prev,
+                    notes: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Evidencias (URL|Descripción, una por línea)
+              </label>
+              <textarea
+                className="min-h-[60px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                placeholder="https://foto.com/epp1.jpg|Equipo completo"
+                value={checkForm.evidenceText}
+                onChange={(event) =>
+                  setCheckForm((prev) => ({
+                    ...prev,
+                    evidenceText: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="md:col-span-2">
+              <button
+                type="submit"
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-500 focus:outline-none"
+              >
+                Registrar chequeo
+              </button>
+            </div>
+          </form>
+        ) : null}
+
+        <div className="space-y-4">
+          {checks.length === 0 ? (
+            <p className="text-sm text-slate-500">
+              Aún no hay chequeos registrados.
+            </p>
+          ) : (
+            checks.map((check) => (
+              <article
+                key={check.id}
+                className="rounded-md border border-slate-200 p-4 text-sm"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-base font-semibold text-slate-900">
+                      {check.title}
+                    </p>
+                    <p className="text-slate-500">
+                      {checkTypeLabels[check.type]} · {formatDate(check.performedAt)}
+                    </p>
+                  </div>
+                  {check.createdBy?.name ? (
+                    <span className="text-xs text-slate-400">
+                      Registrado por {check.createdBy.name}
+                    </span>
+                  ) : null}
+                </div>
+
+                {check.conductedBy ? (
+                  <p className="mt-2 text-slate-600">
+                    Responsable: {check.conductedBy}
+                  </p>
+                ) : null}
+
+                {check.location ? (
+                  <p className="text-slate-600">Ubicación: {check.location}</p>
+                ) : null}
+
+                {check.notes ? (
+                  <p className="mt-2 text-slate-600">Notas: {check.notes}</p>
+                ) : null}
+
+                {check.items && check.items.length > 0 ? (
+                  <ul className="mt-3 list-inside list-disc text-slate-600">
+                    {check.items.map((item, index) => (
+                      <li key={index}>{item.description}</li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                {check.evidence && check.evidence.length > 0 ? (
+                  <div className="mt-3 space-y-1">
+                    <p className="font-medium text-slate-700">Evidencias</p>
+                    <ul className="space-y-1">
+                      {check.evidence.map((item, index) => (
+                        <li key={index}>
+                          <a
+                            href={item.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-indigo-600 hover:underline"
+                          >
+                            {item.description || item.url}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </article>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-4">
+          <h2 className="text-xl font-semibold text-slate-900">
+            Entrega de EPP por persona
+          </h2>
+          <p className="text-sm text-slate-500">
+            Controla las asignaciones y renovaciones de equipos de protección.
+          </p>
+        </div>
+
+        {canEdit ? (
+          <form className="mb-6 grid gap-4 md:grid-cols-2" onSubmit={handleSubmitPpe}>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Colaborador
+              </label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={ppeForm.personName}
+                onChange={(event) =>
+                  setPpeForm((prev) => ({
+                    ...prev,
+                    personName: event.target.value,
+                  }))
+                }
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">Rol</label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={ppeForm.role}
+                onChange={(event) =>
+                  setPpeForm((prev) => ({
+                    ...prev,
+                    role: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Fecha de entrega
+              </label>
+              <input
+                type="date"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={ppeForm.assignedAt}
+                onChange={(event) =>
+                  setPpeForm((prev) => ({
+                    ...prev,
+                    assignedAt: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Entregado por
+              </label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={ppeForm.deliveredBy}
+                onChange={(event) =>
+                  setPpeForm((prev) => ({
+                    ...prev,
+                    deliveredBy: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                EPP entregado (Elemento|Cantidad|Notas, uno por línea)
+              </label>
+              <textarea
+                className="min-h-[80px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                placeholder="Casco|1\nChaleco reflectivo|1|Reposición"
+                value={ppeForm.itemsText}
+                onChange={(event) =>
+                  setPpeForm((prev) => ({
+                    ...prev,
+                    itemsText: event.target.value,
+                  }))
+                }
+                required
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Notas adicionales
+              </label>
+              <textarea
+                className="min-h-[60px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={ppeForm.notes}
+                onChange={(event) =>
+                  setPpeForm((prev) => ({
+                    ...prev,
+                    notes: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Evidencias de entrega (URL|Descripción)
+              </label>
+              <textarea
+                className="min-h-[60px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={ppeForm.evidenceText}
+                onChange={(event) =>
+                  setPpeForm((prev) => ({
+                    ...prev,
+                    evidenceText: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="md:col-span-2">
+              <button
+                type="submit"
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-500 focus:outline-none"
+              >
+                Registrar asignación
+              </button>
+            </div>
+          </form>
+        ) : null}
+
+        <div className="space-y-4">
+          {ppeAssignments.length === 0 ? (
+            <p className="text-sm text-slate-500">
+              No hay asignaciones de EPP registradas.
+            </p>
+          ) : (
+            ppeAssignments.map((assignment) => (
+              <article
+                key={assignment.id}
+                className="rounded-md border border-slate-200 p-4 text-sm"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-base font-semibold text-slate-900">
+                      {assignment.personName}
+                    </p>
+                    <p className="text-slate-500">
+                      {assignment.role ? `${assignment.role} · ` : ''}
+                      {formatDate(assignment.assignedAt)}
+                    </p>
+                  </div>
+                  {assignment.createdBy?.name ? (
+                    <span className="text-xs text-slate-400">
+                      Registrado por {assignment.createdBy.name}
+                    </span>
+                  ) : null}
+                </div>
+
+                {assignment.deliveredBy ? (
+                  <p className="mt-2 text-slate-600">
+                    Entregado por: {assignment.deliveredBy}
+                  </p>
+                ) : null}
+
+                {assignment.notes ? (
+                  <p className="text-slate-600">Notas: {assignment.notes}</p>
+                ) : null}
+
+                {assignment.items && assignment.items.length > 0 ? (
+                  <ul className="mt-3 list-inside list-disc text-slate-600">
+                    {assignment.items.map((item, index) => (
+                      <li key={index}>
+                        {item.item}
+                        {item.quantity ? ` · ${item.quantity}` : ''}
+                        {item.notes ? ` — ${item.notes}` : ''}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                {assignment.evidence && assignment.evidence.length > 0 ? (
+                  <div className="mt-3 space-y-1">
+                    <p className="font-medium text-slate-700">Evidencias</p>
+                    <ul className="space-y-1">
+                      {assignment.evidence.map((item, index) => (
+                        <li key={index}>
+                          <a
+                            href={item.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-indigo-600 hover:underline"
+                          >
+                            {item.description || item.url}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </article>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-4">
+          <h2 className="text-xl font-semibold text-slate-900">
+            Registro de incidentes y condiciones inseguras
+          </h2>
+          <p className="text-sm text-slate-500">
+            Reporta incidentes, adjunta fotos y documenta acciones inmediatas.
+          </p>
+        </div>
+
+        {canEdit ? (
+          <form
+            className="mb-6 grid gap-4 md:grid-cols-2"
+            onSubmit={handleSubmitIncident}
+          >
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Título del incidente
+              </label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={incidentForm.title}
+                onChange={(event) =>
+                  setIncidentForm((prev) => ({
+                    ...prev,
+                    title: event.target.value,
+                  }))
+                }
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Severidad
+              </label>
+              <select
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={incidentForm.severity}
+                onChange={(event) =>
+                  setIncidentForm((prev) => ({
+                    ...prev,
+                    severity: event.target.value as Incident['severity'],
+                  }))
+                }
+              >
+                <option value="baja">Baja</option>
+                <option value="media">Media</option>
+                <option value="alta">Alta</option>
+                <option value="critica">Crítica</option>
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Fecha del evento
+              </label>
+              <input
+                type="date"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={incidentForm.occurredAt}
+                onChange={(event) =>
+                  setIncidentForm((prev) => ({
+                    ...prev,
+                    occurredAt: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">
+                Reportado por
+              </label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={incidentForm.reportedBy}
+                onChange={(event) =>
+                  setIncidentForm((prev) => ({
+                    ...prev,
+                    reportedBy: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Ubicación
+              </label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={incidentForm.location}
+                onChange={(event) =>
+                  setIncidentForm((prev) => ({
+                    ...prev,
+                    location: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Descripción del evento
+              </label>
+              <textarea
+                className="min-h-[80px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={incidentForm.description}
+                onChange={(event) =>
+                  setIncidentForm((prev) => ({
+                    ...prev,
+                    description: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Acciones inmediatas
+              </label>
+              <textarea
+                className="min-h-[60px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={incidentForm.immediateActions}
+                onChange={(event) =>
+                  setIncidentForm((prev) => ({
+                    ...prev,
+                    immediateActions: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Acciones correctivas
+              </label>
+              <textarea
+                className="min-h-[60px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                value={incidentForm.correctiveActions}
+                onChange={(event) =>
+                  setIncidentForm((prev) => ({
+                    ...prev,
+                    correctiveActions: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium text-slate-700">
+                Fotos y evidencias (URL|Descripción)
+              </label>
+              <textarea
+                className="min-h-[80px] w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+                placeholder="https://foto.com/incidente1.jpg|Vista área impacto"
+                value={incidentForm.photosText}
+                onChange={(event) =>
+                  setIncidentForm((prev) => ({
+                    ...prev,
+                    photosText: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="md:col-span-2">
+              <button
+                type="submit"
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-500 focus:outline-none"
+              >
+                Reportar incidente
+              </button>
+            </div>
+          </form>
+        ) : null}
+
+        <div className="space-y-4">
+          {incidents.length === 0 ? (
+            <p className="text-sm text-slate-500">
+              No hay incidentes reportados.
+            </p>
+          ) : (
+            incidents.map((incident) => (
+              <article
+                key={incident.id}
+                className="rounded-md border border-slate-200 p-4 text-sm"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-base font-semibold text-slate-900">
+                      {incident.title}
+                    </p>
+                    <p className="text-slate-500">
+                      {severityLabels[incident.severity]} ·{' '}
+                      {formatDate(incident.occurredAt)}
+                    </p>
+                  </div>
+                  {incident.createdBy?.name ? (
+                    <span className="text-xs text-slate-400">
+                      Registrado por {incident.createdBy.name}
+                    </span>
+                  ) : null}
+                </div>
+
+                {incident.location ? (
+                  <p className="mt-2 text-slate-600">
+                    Ubicación: {incident.location}
+                  </p>
+                ) : null}
+
+                {incident.reportedBy ? (
+                  <p className="text-slate-600">
+                    Reportado por: {incident.reportedBy}
+                  </p>
+                ) : null}
+
+                {incident.description ? (
+                  <p className="mt-2 text-slate-600">
+                    Descripción: {incident.description}
+                  </p>
+                ) : null}
+
+                {incident.immediateActions ? (
+                  <p className="mt-2 text-slate-600">
+                    Acciones inmediatas: {incident.immediateActions}
+                  </p>
+                ) : null}
+
+                {incident.correctiveActions ? (
+                  <p className="text-slate-600">
+                    Acciones correctivas: {incident.correctiveActions}
+                  </p>
+                ) : null}
+
+                {incident.photos && incident.photos.length > 0 ? (
+                  <div className="mt-3 space-y-1">
+                    <p className="font-medium text-slate-700">Evidencias</p>
+                    <ul className="space-y-1">
+                      {incident.photos.map((photo, index) => (
+                        <li key={index}>
+                          <a
+                            href={photo.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-indigo-600 hover:underline"
+                          >
+                            {photo.description || photo.url}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </article>
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/pages/ProjectPage.tsx
+++ b/web/src/pages/ProjectPage.tsx
@@ -27,6 +27,7 @@ const TAB_TO_PATH: Record<string, string> = {
   processes: 'procesos',
   systems: 'systems',
   fiveS: '5s',
+  hse: 'hse',
   inventory: 'inventory',
   security: 'security',
   risks: 'risks',


### PR DESCRIPTION
## Summary
- add Prisma models for HSE checks, PPE assignments, and incidents with audit metadata
- expose new /hse API routes wired into the application router
- build an HSE project tab to manage checklists, PPE deliveries, and incident reports

## Testing
- npm --prefix api run lint *(fails: existing repository lint errors unrelated to this change)*
- npm --prefix web run build


------
https://chatgpt.com/codex/tasks/task_e_68def3ccc330833192523467e0be1afe