### PR TITLE
layout: capacidad por zona y simulador

### DIFF
--- a/api/prisma/migrations/20251101090000_layout_capacidad/migration.sql
+++ b/api/prisma/migrations/20251101090000_layout_capacidad/migration.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "CapacityCalc" (
+    "id" TEXT NOT NULL,
+    "zoneId" TEXT NOT NULL,
+    "rackType" TEXT NOT NULL,
+    "aisles" INTEGER NOT NULL,
+    "pp" INTEGER NOT NULL,
+    "memo" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CapacityCalc_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "CapacityCalc_zoneId_idx" ON "CapacityCalc"("zoneId");
+
+ALTER TABLE "CapacityCalc" ADD CONSTRAINT "CapacityCalc_zoneId_fkey" FOREIGN KEY ("zoneId") REFERENCES "WarehouseZone"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -989,6 +989,7 @@ model WarehouseZone {
   racks     Rack[]
   locations Location[]
   tasks     InventoryTask[]
+  capacityCalcs CapacityCalc[]
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
 
@@ -1036,6 +1037,20 @@ model Location {
   @@index([projectId])
   @@index([zoneId])
   @@index([rackId])
+}
+
+model CapacityCalc {
+  id        String        @id @default(cuid())
+  zoneId    String
+  zone      WarehouseZone @relation(fields: [zoneId], references: [id])
+  rackType  String
+  aisles    Int
+  pp        Int
+  memo      Json?
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+
+  @@index([zoneId])
 }
 
 model Sku {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -32,6 +32,7 @@ import { interviewRouter } from './modules/interviews/interview.router.js';
 import { inventoryRouter } from './modules/inventory/inventory.router.js';
 import { fiveSRouter } from './modules/fiveS/five-s.router.js';
 import { hseRouter } from './modules/hse/hse.router.js';
+import { layoutRouter } from './modules/layout/layout.router.js';
 
 const appRouter = Router();
 
@@ -67,5 +68,6 @@ appRouter.use('/interviews', interviewRouter);
 appRouter.use('/inventory', inventoryRouter);
 appRouter.use('/fiveS', fiveSRouter);
 appRouter.use('/hse', hseRouter);
+appRouter.use('/layout', layoutRouter);
 
 export { appRouter };

--- a/api/src/modules/layout/layout.router.ts
+++ b/api/src/modules/layout/layout.router.ts
@@ -1,0 +1,104 @@
+import { Router } from 'express';
+import multer from 'multer';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+import { authenticate, requireProjectRole, type AuthenticatedRequest } from '../../core/middleware/auth.js';
+import { enforceProjectAccess } from '../../core/security/enforce-project-access.js';
+import { layoutService } from './layout.service.js';
+
+const upload = multer({
+  dest: path.join(process.cwd(), 'tmp'),
+  storage: multer.diskStorage({
+    destination: path.join(process.cwd(), 'tmp'),
+    filename: (_req, file, cb) => cb(null, `${randomUUID()}-${file.originalname}`),
+  }),
+});
+
+const viewerRoles = ['ConsultorLider', 'Auditor', 'SponsorPM', 'Invitado'];
+const editorRoles = ['ConsultorLider', 'Auditor'];
+
+const layoutRouter = Router();
+
+layoutRouter.use(authenticate);
+
+layoutRouter.get('/projects/:projectId', requireProjectRole(viewerRoles), async (req: AuthenticatedRequest, res) => {
+  const { projectId } = req.params;
+  const result = await layoutService.getProjectLayout(projectId);
+  res.json(result);
+});
+
+layoutRouter.post(
+  '/projects/:projectId/plan',
+  requireProjectRole(editorRoles),
+  upload.single('plan'),
+  async (req: AuthenticatedRequest, res) => {
+    const { projectId } = req.params;
+    if (!req.file) {
+      return res.status(400).json({ message: 'Archivo de plano requerido' });
+    }
+    const plan = await layoutService.updatePlan(projectId, req.file, req.user!.id);
+    res.status(201).json(plan);
+  },
+);
+
+layoutRouter.post('/projects/:projectId/capacity', requireProjectRole(editorRoles), async (req: AuthenticatedRequest, res) => {
+  const { projectId } = req.params;
+  const body = req.body as { rows?: unknown; memo?: unknown };
+
+  if (!Array.isArray(body.rows) || body.rows.length === 0) {
+    return res.status(400).json({ message: 'rows requerido' });
+  }
+
+  const parsedRows = body.rows
+    .map((row) => {
+      if (typeof row !== 'object' || row === null) {
+        return null;
+      }
+      const value = row as Record<string, unknown>;
+      const zoneId = typeof value.zoneId === 'string' ? value.zoneId : null;
+      const rackType = typeof value.rackType === 'string' ? value.rackType.trim() : null;
+      const aislesRaw = value.aisles as unknown;
+      const ppRaw = value.pp as unknown;
+      const aisles = Number(aislesRaw);
+      const pp = Number(ppRaw);
+
+      if (!zoneId || !rackType) {
+        return null;
+      }
+
+      if (!Number.isFinite(aisles) || !Number.isFinite(pp)) {
+        return null;
+      }
+
+      return {
+        zoneId,
+        rackType,
+        aisles: Math.max(0, Math.round(aisles)),
+        pp: Math.max(0, Math.round(pp)),
+      };
+    })
+    .filter(Boolean) as { zoneId: string; rackType: string; aisles: number; pp: number }[];
+
+  if (parsedRows.length === 0) {
+    return res.status(400).json({ message: 'rows inválido' });
+  }
+
+  const simulation = await layoutService.saveSimulation(projectId, parsedRows, body.memo ?? null);
+  res.status(201).json(simulation);
+});
+
+layoutRouter.get('/zones/:zoneId/capacity', async (req: AuthenticatedRequest, res) => {
+  const { zoneId } = req.params;
+  const projectId = await layoutService.getZoneProject(zoneId);
+  if (!projectId) {
+    return res.status(404).json({ message: 'Zona no encontrada' });
+  }
+
+  await enforceProjectAccess(req.user, projectId);
+
+  const calcs = await layoutService.listZoneCalcs(zoneId);
+  res.json(calcs);
+});
+
+export { layoutRouter };

--- a/api/src/modules/layout/layout.service.ts
+++ b/api/src/modules/layout/layout.service.ts
@@ -1,0 +1,196 @@
+import fs from 'fs/promises';
+
+import type { CapacityCalc, File as FileRecord } from '@prisma/client';
+
+import { prisma } from '../../core/config/db.js';
+import { fileService } from '../files/file.service.js';
+
+interface SimulationRow {
+  zoneId: string;
+  rackType: string;
+  aisles: number;
+  pp: number;
+}
+
+const normalizeMemo = (memo: unknown, totalPP: number) => {
+  const timestamp = new Date().toISOString();
+  if (memo === null || memo === undefined) {
+    return { totalPP, savedAt: timestamp } as Record<string, unknown>;
+  }
+  if (typeof memo === 'string') {
+    return { notes: memo, totalPP, savedAt: timestamp };
+  }
+  if (typeof memo === 'object') {
+    return { ...(memo as Record<string, unknown>), totalPP, savedAt: timestamp };
+  }
+  return { value: memo, totalPP, savedAt: timestamp };
+};
+
+const readPlanDataUrl = async (file: FileRecord) => {
+  try {
+    const buffer = await fs.readFile(file.path);
+    const base64 = buffer.toString('base64');
+    return `data:${file.mime};base64,${base64}`;
+  } catch (error) {
+    return null;
+  }
+};
+
+const toPlanResponse = (file: FileRecord, dataUrl: string | null) => ({
+  id: file.id,
+  filename: file.filename,
+  mime: file.mime,
+  size: file.size,
+  createdAt: file.createdAt,
+  uploadedBy: file.uploadedBy,
+  dataUrl,
+});
+
+export const layoutService = {
+  async getProjectLayout(projectId: string) {
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { settings: true },
+    });
+
+    if (!project) {
+      throw new Error('Proyecto no encontrado');
+    }
+
+    const rawSettings = project.settings;
+    const settings =
+      rawSettings && typeof rawSettings === 'object' ? (rawSettings as Record<string, unknown>) : {};
+    const planFileId = typeof settings.layoutPlanFileId === 'string' ? settings.layoutPlanFileId : null;
+
+    let plan: ReturnType<typeof toPlanResponse> | null = null;
+    if (planFileId) {
+      const planFile = await prisma.file.findUnique({ where: { id: planFileId } });
+      if (planFile) {
+        const dataUrl = await readPlanDataUrl(planFile);
+        plan = toPlanResponse(planFile, dataUrl);
+      }
+    }
+
+    const zones = await prisma.warehouseZone.findMany({
+      where: { projectId },
+      orderBy: { code: 'asc' },
+      include: {
+        capacityCalcs: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+        },
+      },
+    });
+
+    const zoneEntries = zones.map((zone) => {
+      const latest = zone.capacityCalcs[0] ?? null;
+      return {
+        id: zone.id,
+        code: zone.code,
+        name: zone.name,
+        latestCalc: latest
+          ? {
+              id: latest.id,
+              rackType: latest.rackType,
+              aisles: latest.aisles,
+              pp: latest.pp,
+              memo: latest.memo,
+              createdAt: latest.createdAt,
+              updatedAt: latest.updatedAt,
+            }
+          : null,
+      };
+    });
+
+    const totalPP = zoneEntries.reduce((sum, zone) => sum + (zone.latestCalc?.pp ?? 0), 0);
+
+    return { plan, zones: zoneEntries, totalPP };
+  },
+
+  async updatePlan(projectId: string, file: Express.Multer.File, userId: string) {
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { id: true, settings: true },
+    });
+
+    if (!project) {
+      throw new Error('Proyecto no encontrado');
+    }
+
+    const savedFile = await fileService.save(projectId, file, userId);
+
+    const rawSettings = project.settings;
+    const settings =
+      rawSettings && typeof rawSettings === 'object' ? (rawSettings as Record<string, unknown>) : {};
+
+    await prisma.project.update({
+      where: { id: projectId },
+      data: {
+        settings: { ...settings, layoutPlanFileId: savedFile.id },
+      },
+    });
+
+    const dataUrl = await readPlanDataUrl(savedFile);
+
+    return toPlanResponse(savedFile, dataUrl);
+  },
+
+  async saveSimulation(projectId: string, rows: SimulationRow[], memo: unknown) {
+    if (rows.length === 0) {
+      return { totalPP: 0, created: [] as CapacityCalc[] };
+    }
+
+    const zoneIds = rows.map((row) => row.zoneId);
+    const zones = await prisma.warehouseZone.findMany({
+      where: { projectId, id: { in: zoneIds } },
+      select: { id: true },
+    });
+
+    if (zones.length !== rows.length) {
+      throw new Error('Una o más zonas no pertenecen al proyecto');
+    }
+
+    const totalPP = rows.reduce((sum, row) => sum + row.pp, 0);
+    const memoPayload = normalizeMemo(memo, totalPP);
+
+    const created = await prisma.$transaction(
+      rows.map((row) =>
+        prisma.capacityCalc.create({
+          data: {
+            zoneId: row.zoneId,
+            rackType: row.rackType,
+            aisles: row.aisles,
+            pp: row.pp,
+            memo: memoPayload,
+          },
+        }),
+      ),
+    );
+
+    return { totalPP, created };
+  },
+
+  async listZoneCalcs(zoneId: string) {
+    const zone = await prisma.warehouseZone.findUnique({
+      where: { id: zoneId },
+      select: { id: true },
+    });
+
+    if (!zone) {
+      throw new Error('Zona no encontrada');
+    }
+
+    return prisma.capacityCalc.findMany({
+      where: { zoneId },
+      orderBy: { createdAt: 'desc' },
+    });
+  },
+
+  async getZoneProject(zoneId: string) {
+    const zone = await prisma.warehouseZone.findUnique({
+      where: { id: zoneId },
+      select: { projectId: true },
+    });
+    return zone?.projectId ?? null;
+  },
+};

--- a/web/src/features/layout/LayoutTab.tsx
+++ b/web/src/features/layout/LayoutTab.tsx
@@ -1,0 +1,387 @@
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import api from '../../lib/api';
+
+const RACK_TYPES = [
+  { value: 'selectivo', label: 'Selectivo', ppPerAisle: 60 },
+  { value: 'doble-profundidad', label: 'Doble profundidad', ppPerAisle: 72 },
+  { value: 'drive-in', label: 'Drive-In', ppPerAisle: 84 },
+  { value: 'dinamico', label: 'Dinámico', ppPerAisle: 48 },
+  { value: 'push-back', label: 'Push-Back', ppPerAisle: 66 },
+] as const;
+
+const DEFAULT_RACK_TYPE = RACK_TYPES[0].value;
+
+interface LayoutPlan {
+  id: string;
+  filename: string;
+  mime: string;
+  size: number;
+  createdAt: string;
+  uploadedBy: string;
+  dataUrl: string | null;
+}
+
+interface LayoutZoneRow {
+  id: string;
+  code: string;
+  name: string;
+  rackType: string;
+  aisles: number;
+  pp: number;
+  updatedAt?: string;
+  memoNote?: string;
+}
+
+interface LayoutApiResponse {
+  plan: LayoutPlan | null;
+  zones: {
+    id: string;
+    code: string;
+    name: string;
+    latestCalc: {
+      id: string;
+      rackType: string;
+      aisles: number;
+      pp: number;
+      memo?: unknown;
+      createdAt: string;
+      updatedAt: string;
+    } | null;
+  }[];
+  totalPP: number;
+}
+
+interface LayoutTabProps {
+  projectId: string;
+}
+
+const calculatePP = (aisles: number, rackType: string) => {
+  const option = RACK_TYPES.find((item) => item.value === rackType) ?? RACK_TYPES[0];
+  return Math.max(0, Math.round(aisles * option.ppPerAisle));
+};
+
+const formatDateTime = (value?: string) => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('es-CL', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+};
+
+const extractMemoNote = (memo: unknown): string | undefined => {
+  if (!memo || typeof memo !== 'object') {
+    return undefined;
+  }
+  const record = memo as Record<string, unknown>;
+  const note = record.notes ?? record.note ?? record.memo;
+  return typeof note === 'string' ? note : undefined;
+};
+
+const LayoutTab = ({ projectId }: LayoutTabProps) => {
+  const [plan, setPlan] = useState<LayoutPlan | null>(null);
+  const [rows, setRows] = useState<LayoutZoneRow[]>([]);
+  const [baselineTotal, setBaselineTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [memoText, setMemoText] = useState('');
+
+  const fetchLayout = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.get<LayoutApiResponse>(`/layout/projects/${projectId}`);
+      const data = response.data;
+      setPlan(data.plan ?? null);
+      setBaselineTotal(data.totalPP ?? 0);
+
+      const mappedRows = data.zones.map<LayoutZoneRow>((zone) => {
+        const rackType = zone.latestCalc?.rackType ?? DEFAULT_RACK_TYPE;
+        const aisles = zone.latestCalc?.aisles ?? 0;
+        const pp = zone.latestCalc?.pp ?? calculatePP(aisles, rackType);
+        return {
+          id: zone.id,
+          code: zone.code,
+          name: zone.name,
+          rackType,
+          aisles,
+          pp,
+          updatedAt: zone.latestCalc?.updatedAt ?? zone.latestCalc?.createdAt,
+          memoNote: extractMemoNote(zone.latestCalc?.memo),
+        };
+      });
+
+      setRows(mappedRows);
+      setSuccess(null);
+    } catch (err) {
+      console.error('No se pudo cargar el layout', err);
+      setError('No se pudo cargar la información de layout y capacidad.');
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    fetchLayout();
+  }, [fetchLayout]);
+
+  const totalWhatIf = useMemo(
+    () => rows.reduce((accumulator, row) => accumulator + row.pp, 0),
+    [rows],
+  );
+
+  const handleRackTypeChange = (zoneId: string, value: string) => {
+    setRows((previous) =>
+      previous.map((row) =>
+        row.id === zoneId
+          ? {
+              ...row,
+              rackType: value,
+              pp: calculatePP(row.aisles, value),
+            }
+          : row,
+      ),
+    );
+  };
+
+  const handleAislesChange = (zoneId: string, value: string) => {
+    const parsed = Number(value);
+    const aisles = Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+    setRows((previous) =>
+      previous.map((row) =>
+        row.id === zoneId
+          ? {
+              ...row,
+              aisles,
+              pp: calculatePP(aisles, row.rackType),
+            }
+          : row,
+      ),
+    );
+  };
+
+  const handleMemoChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setMemoText(event.target.value);
+  };
+
+  const handlePlanUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setError(null);
+    setSuccess(null);
+    try {
+      const formData = new FormData();
+      formData.append('plan', file);
+      await api.post(`/layout/projects/${projectId}/plan`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      await fetchLayout();
+    } catch (err) {
+      console.error('No se pudo subir el plano', err);
+      setError('No se pudo subir el plano del layout.');
+    } finally {
+      event.target.value = '';
+    }
+  };
+
+  const handleSaveSimulation = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const payload = {
+        rows: rows.map(({ id, rackType, aisles, pp }) => ({
+          zoneId: id,
+          rackType,
+          aisles,
+          pp,
+        })),
+        memo: memoText.trim().length > 0 ? { notes: memoText.trim() } : {},
+      };
+      await api.post(`/layout/projects/${projectId}/capacity`, payload);
+      setSuccess('Simulación guardada correctamente.');
+      setMemoText('');
+      await fetchLayout();
+    } catch (err) {
+      console.error('No se pudo guardar la simulación de capacidad', err);
+      setError('No se pudo guardar la simulación. Verifica los datos e inténtalo nuevamente.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Plano del layout</h2>
+            <p className="text-sm text-slate-500">
+              Carga una imagen del plano para utilizarla como referencia al simular capacidad.
+            </p>
+          </div>
+          <label className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50">
+            <input className="hidden" type="file" accept="image/*" onChange={handlePlanUpload} />
+            <span>Actualizar plano</span>
+          </label>
+        </div>
+        <div className="mt-4 overflow-hidden rounded-md border border-dashed border-slate-300 bg-slate-50">
+          {plan?.dataUrl ? (
+            <img
+              src={plan.dataUrl}
+              alt={`Plano de layout ${plan.filename}`}
+              className="h-auto w-full max-h-[480px] object-contain bg-white"
+            />
+          ) : (
+            <div className="flex h-48 items-center justify-center text-sm text-slate-500">
+              No hay un plano cargado para este proyecto.
+            </div>
+          )}
+        </div>
+        {plan ? (
+          <p className="mt-2 text-xs text-slate-500">
+            Última actualización: {formatDateTime(plan.createdAt)} · {plan.filename}
+          </p>
+        ) : null}
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Capacidad por zona</h2>
+            <p className="text-sm text-slate-500">
+              Ajusta el tipo de rack y la cantidad de pasillos para simular posiciones de pallets (PP) por zona.
+            </p>
+          </div>
+          <div className="text-sm text-slate-600">
+            <p>PP actual registradas: <span className="font-semibold text-slate-900">{baselineTotal}</span></p>
+            <p>
+              PP simuladas (what-if):{' '}
+              <span className="font-semibold text-indigo-600">{totalWhatIf}</span>
+            </p>
+          </div>
+        </header>
+
+        {error ? (
+          <p className="mt-4 rounded-md border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>
+        ) : null}
+        {success ? (
+          <p className="mt-4 rounded-md border border-green-200 bg-green-50 px-4 py-2 text-sm text-green-700">{success}</p>
+        ) : null}
+
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+            <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th scope="col" className="px-3 py-2">
+                  Zona
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Tipo de rack
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Pasillos
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  PP simuladas
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Última simulación
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Nota
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 bg-white">
+              {rows.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-3 py-6 text-center text-sm text-slate-500">
+                    {loading ? 'Cargando zonas…' : 'No hay zonas configuradas para este proyecto.'}
+                  </td>
+                </tr>
+              ) : (
+                rows.map((row) => (
+                  <tr key={row.id}>
+                    <td className="whitespace-nowrap px-3 py-3 font-medium text-slate-900">
+                      <div className="font-semibold">{row.code}</div>
+                      <div className="text-xs text-slate-500">{row.name}</div>
+                    </td>
+                    <td className="px-3 py-3">
+                      <select
+                        value={row.rackType}
+                        onChange={(event) => handleRackTypeChange(row.id, event.target.value)}
+                        className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                      >
+                        {RACK_TYPES.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td className="px-3 py-3">
+                      <input
+                        type="number"
+                        inputMode="numeric"
+                        min={0}
+                        value={row.aisles}
+                        onChange={(event) => handleAislesChange(row.id, event.target.value)}
+                        className="mt-1 block w-24 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                      />
+                    </td>
+                    <td className="px-3 py-3 text-right text-sm font-semibold text-slate-900">
+                      {row.pp}
+                    </td>
+                    <td className="px-3 py-3 text-xs text-slate-500">{formatDateTime(row.updatedAt)}</td>
+                    <td className="px-3 py-3 text-xs text-slate-500">
+                      {row.memoNote ? row.memoNote : <span className="text-slate-400">—</span>}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-[2fr,1fr]">
+          <div>
+            <label htmlFor="layoutMemo" className="block text-sm font-medium text-slate-700">
+              Memoria de cálculo
+            </label>
+            <textarea
+              id="layoutMemo"
+              value={memoText}
+              onChange={handleMemoChange}
+              rows={4}
+              placeholder="Describe supuestos, restricciones o notas de la simulación."
+              className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+          </div>
+          <div className="flex flex-col justify-between gap-4">
+            <div className="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+              <p>
+                El what-if aplica factores de PP por pasillo según el tipo de rack seleccionado. Ajusta los valores y guarda la
+                simulación para registrar el total y la memoria de cálculo.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleSaveSimulation}
+              disabled={saving || rows.length === 0}
+              className="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-300"
+            >
+              {saving ? 'Guardando…' : 'Guardar simulación'}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default LayoutTab;

--- a/web/src/features/projects/ProjectTabs.tsx
+++ b/web/src/features/projects/ProjectTabs.tsx
@@ -16,6 +16,7 @@ import FindingsTab from './tabs/FindingsTab';
 import WorkflowTab from './tabs/WorkflowTab';
 import GovernanceTab from './tabs/GovernanceTab';
 import InventoryTab from '../inventory/InventoryTab';
+import LayoutTab from '../layout/LayoutTab';
 import FiveSTab from './tabs/FiveSTab';
 import HseTab from './tabs/HseTab';
 
@@ -50,6 +51,7 @@ export const ProjectTabs: {
   { value: 'fiveS', label: '5S', component: FiveSTab },
   { value: 'hse', label: 'HSE', component: HseTab },
   { value: 'inventory', label: 'Maestro & Etiquetas', component: InventoryTab },
+  { value: 'layout', label: 'Layout & Capacidad', component: LayoutTab },
   { value: 'security', label: 'Seguridad', component: SecurityTab },
   { value: 'risks', label: 'Riesgos', component: RisksTab },
   { value: 'findings', label: 'Hallazgos', component: FindingsTab },

--- a/web/src/pages/ProjectPage.tsx
+++ b/web/src/pages/ProjectPage.tsx
@@ -29,6 +29,7 @@ const TAB_TO_PATH: Record<string, string> = {
   fiveS: '5s',
   hse: 'hse',
   inventory: 'inventory',
+  layout: 'layout',
   security: 'security',
   risks: 'risks',
   findings: 'findings',


### PR DESCRIPTION
## Summary
- agregar el modelo `CapacityCalc` y la migración asociada para registrar simulaciones de capacidad por zona
- exponer endpoints de layout para cargar planos y guardar escenarios de capacidad vinculados a las zonas del proyecto
- incorporar una nueva pestaña de "Layout & Capacidad" en la web con carga de plano e interfaz what-if para PP por zona

## Testing
- npx prisma migrate dev --name layout_capacidad *(falla: base de datos no disponible en el entorno)*
- npm run lint *(api, falla por configuraciones y rutas preexistentes)*
- npm run lint *(web, falla por reglas de formato preexistentes)*

------
https://chatgpt.com/codex/tasks/task_e_68def7eeefec83319757031d7a9c9374