### PR TITLE
kpi: snapshots diarios y tablero

### DIFF
--- a/api/src/modules/kpis/kpi-snapshot.job.ts
+++ b/api/src/modules/kpis/kpi-snapshot.job.ts
@@ -1,0 +1,143 @@
+import { prisma } from '../../core/config/db.js';
+import { logger } from '../../core/config/logger.js';
+
+const startOfUtcDay = (date: Date) =>
+  new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+
+const createRandomGenerator = (projectId: string, date: Date) => {
+  const projectHash = Array.from(projectId).reduce((acc, char, index) => {
+    return acc + char.charCodeAt(0) * (index + 1);
+  }, 0);
+  const dateKey = Number.parseInt(date.toISOString().slice(0, 10).replaceAll('-', ''), 10);
+
+  let seed = (projectHash * 9301 + dateKey * 49297) % 233280;
+
+  return () => {
+    seed = (seed * 9301 + 49297) % 233280;
+    return seed / 233280;
+  };
+};
+
+const round = (value: number, precision = 2) => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+const buildSnapshotPayload = (projectId: string, snapshotDate: Date) => {
+  const random = createRandomGenerator(projectId, snapshotDate);
+
+  const otif = round(92 + random() * 6, 2);
+  const pickPerHour = round(70 + random() * 15, 2);
+  const inventoryAccuracy = round(94 + random() * 5, 2);
+  const occupancyPct = round(60 + random() * 25, 2);
+  const costPerOrder = round(3 + random() * 4, 2);
+  const kmPerDrop = round(8 + random() * 12, 2);
+
+  return {
+    date: snapshotDate,
+    otif,
+    pickPerHour,
+    inventoryAccuracy,
+    occupancyPct,
+    costPerOrder,
+    kmPerDrop,
+  };
+};
+
+const createJob = () => {
+  let timer: NodeJS.Timeout | null = null;
+  let running = false;
+
+  const scheduleNextRun = () => {
+    const now = new Date();
+    const nextExecution = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+    );
+    const delay = Math.max(nextExecution.getTime() - now.getTime(), 1000);
+
+    timer = setTimeout(() => {
+      runJob()
+        .catch((error) => {
+          logger.error({ err: error }, 'Error ejecutando job diario de KPI');
+        })
+        .finally(() => {
+          scheduleNextRun();
+        });
+    }, delay);
+  };
+
+  const runJob = async () => {
+    if (running) {
+      logger.warn('Job diario de KPI ya se encuentra en ejecución, se omite nueva instancia');
+      return;
+    }
+
+    running = true;
+    const executionDate = new Date();
+    const snapshotDate = startOfUtcDay(executionDate);
+
+    try {
+      const projects = await prisma.project.findMany({ select: { id: true } });
+
+      for (const project of projects) {
+        const data = buildSnapshotPayload(project.id, snapshotDate);
+        const existing = await prisma.kpiSnapshot.findFirst({
+          where: { projectId: project.id, date: snapshotDate },
+          select: { id: true },
+        });
+
+        if (existing) {
+          await prisma.kpiSnapshot.update({
+            where: { id: existing.id },
+            data,
+          });
+        } else {
+          await prisma.kpiSnapshot.create({
+            data: {
+              ...data,
+              projectId: project.id,
+            },
+          });
+        }
+      }
+
+      logger.info(
+        {
+          projectCount: projects.length,
+          snapshotDate: snapshotDate.toISOString(),
+        },
+        'Snapshots KPI generados automáticamente',
+      );
+    } catch (error) {
+      logger.error({ err: error }, 'No se pudieron generar los snapshots KPI diarios');
+    } finally {
+      running = false;
+    }
+  };
+
+  return {
+    start: () => {
+      runJob()
+        .catch((error) => {
+          logger.error({ err: error }, 'Error inicial al generar snapshots KPI');
+        })
+        .finally(() => {
+          scheduleNextRun();
+        });
+    },
+    stop: () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+};
+
+export const startKpiSnapshotCron = () => {
+  const job = createJob();
+  job.start();
+  return job;
+};
+
+export type KpiSnapshotCron = ReturnType<typeof createJob>;

--- a/api/src/modules/kpis/kpi.service.ts
+++ b/api/src/modules/kpis/kpi.service.ts
@@ -2,11 +2,28 @@ import { prisma } from '../../core/config/db.js';
 import { HttpError } from '../../core/errors/http-error.js';
 import { auditService } from '../audit/audit.service.js';
 
+type KpiListFilters = {
+  startDate?: Date;
+  endDate?: Date;
+};
+
 export const kpiService = {
-  async list(projectId: string) {
+  async list(projectId: string, filters: KpiListFilters = {}) {
+    const { startDate, endDate } = filters;
+
     return prisma.kpiSnapshot.findMany({
-      where: { projectId },
-      orderBy: { date: 'desc' },
+      where: {
+        projectId,
+        ...(startDate || endDate
+          ? {
+              date: {
+                ...(startDate ? { gte: startDate } : {}),
+                ...(endDate ? { lte: endDate } : {}),
+              },
+            }
+          : {}),
+      },
+      orderBy: { date: 'asc' },
     });
   },
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -22,6 +22,7 @@ import { initializeQueueWorkers } from './services/queue.js';
 import { startApprovalSlaMonitor } from './services/approval-sla.js';
 import surveysRouter from './routes/surveys.js';
 import { zodErrorHandler } from './common/validation/zod-error.middleware.js';
+import { startKpiSnapshotCron } from './modules/kpis/kpi-snapshot.job.js';
 
 const app = express();
 
@@ -143,6 +144,7 @@ initializeQueueWorkers().catch((error) => {
 
 if (env.nodeEnv !== 'test') {
   startApprovalSlaMonitor();
+  startKpiSnapshotCron();
 }
 
 export { app, server };

--- a/web/src/features/projects/components/TimeSeriesChart.tsx
+++ b/web/src/features/projects/components/TimeSeriesChart.tsx
@@ -1,0 +1,228 @@
+import { useMemo } from 'react';
+
+const CHART_WIDTH = 360;
+const CHART_HEIGHT = 200;
+const PADDING_X = 36;
+const PADDING_Y = 28;
+
+export interface TimeSeriesPoint {
+  date: Date | string;
+  value: number | null | undefined;
+}
+
+export interface TimeSeriesChartProps {
+  title: string;
+  unit?: string;
+  data: TimeSeriesPoint[];
+  color?: string;
+  valueFormatter?: (value: number) => string;
+}
+
+interface NormalizedPoint {
+  date: Date;
+  value: number | null;
+}
+
+const dateFormatter = new Intl.DateTimeFormat('es-ES', {
+  day: '2-digit',
+  month: 'short',
+});
+
+const defaultValueFormatter = (value: number) => value.toFixed(2);
+
+const normalizePoints = (points: TimeSeriesPoint[]): NormalizedPoint[] =>
+  points
+    .map((point) => ({
+      date: point.date instanceof Date ? point.date : new Date(point.date),
+      value:
+        typeof point.value === 'number' && Number.isFinite(point.value)
+          ? point.value
+          : null,
+    }))
+    .filter((point) => !Number.isNaN(point.date.getTime()))
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+export const TimeSeriesChart = ({
+  title,
+  unit,
+  data,
+  color = '#2563eb',
+  valueFormatter = defaultValueFormatter,
+}: TimeSeriesChartProps) => {
+  const normalized = useMemo(() => normalizePoints(data), [data]);
+  const validPoints = useMemo(
+    () => normalized.filter((point) => point.value !== null),
+    [normalized]
+  );
+
+  const minDate = normalized[0]?.date ?? new Date();
+  const maxDate = normalized[normalized.length - 1]?.date ?? minDate;
+  const dateRange = Math.max(maxDate.getTime() - minDate.getTime(), 1);
+
+  const valueExtent = useMemo(() => {
+    if (validPoints.length === 0) {
+      return { min: 0, max: 1 };
+    }
+    const values = validPoints.map((point) => point.value ?? 0);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    if (min === max) {
+      return { min: min - 1, max: max + 1 };
+    }
+    return { min, max };
+  }, [validPoints]);
+
+  const valueRange = Math.max(valueExtent.max - valueExtent.min, 1);
+
+  const getX = (date: Date) => {
+    if (dateRange === 0) return CHART_WIDTH / 2;
+    const position = (date.getTime() - minDate.getTime()) / dateRange;
+    return PADDING_X + position * (CHART_WIDTH - PADDING_X * 2);
+  };
+
+  const getY = (value: number) => {
+    const ratio = (value - valueExtent.min) / valueRange;
+    return CHART_HEIGHT - PADDING_Y - ratio * (CHART_HEIGHT - PADDING_Y * 2);
+  };
+
+  const pathD = useMemo(() => {
+    if (validPoints.length === 0) return '';
+    let path = '';
+    let started = false;
+
+    normalized.forEach((point) => {
+      if (point.value === null) {
+        started = false;
+        return;
+      }
+
+      const command = started ? 'L' : 'M';
+      const x = getX(point.date).toFixed(2);
+      const y = getY(point.value).toFixed(2);
+      path += `${command}${x} ${y}`;
+      started = true;
+    });
+
+    return path;
+  }, [normalized, validPoints.length, getX, getY]);
+
+  const latestValue = validPoints[validPoints.length - 1]?.value ?? null;
+  const rangeLabel = normalized.length
+    ? `${dateFormatter.format(minDate)} – ${dateFormatter.format(maxDate)}`
+    : 'Sin datos disponibles';
+
+  const valueTicks = useMemo(() => {
+    const steps = 4;
+    return Array.from({ length: steps }, (_, index) => {
+      const ratio = index / (steps - 1);
+      const value = valueExtent.min + ratio * valueRange;
+      return {
+        value,
+        y: getY(value),
+        label: valueFormatter(value),
+      };
+    });
+  }, [valueExtent.min, valueRange, valueFormatter, getY]);
+
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-slate-500">{title}</p>
+          <p className="text-2xl font-semibold text-slate-900">
+            {latestValue === null ? '—' : valueFormatter(latestValue)}
+            {unit ? ` ${unit}` : ''}
+          </p>
+        </div>
+        <span className="text-xs text-slate-400">{rangeLabel}</span>
+      </div>
+
+      <div className="overflow-hidden">
+        <svg
+          role="img"
+          aria-label={`${title} (${rangeLabel})`}
+          width="100%"
+          viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        >
+          <rect
+            x={PADDING_X}
+            y={PADDING_Y}
+            width={CHART_WIDTH - PADDING_X * 2}
+            height={CHART_HEIGHT - PADDING_Y * 2}
+            fill="#f8fafc"
+            stroke="#e2e8f0"
+            strokeWidth={1}
+            rx={8}
+          />
+
+          {valueTicks.map((tick) => (
+            <g key={tick.label}>
+              <line
+                x1={PADDING_X}
+                x2={CHART_WIDTH - PADDING_X}
+                y1={tick.y}
+                y2={tick.y}
+                stroke="#e2e8f0"
+                strokeDasharray="4 4"
+              />
+              <text
+                x={PADDING_X - 8}
+                y={tick.y + 4}
+                textAnchor="end"
+                className="fill-slate-400 text-xs"
+              >
+                {tick.label}
+              </text>
+            </g>
+          ))}
+
+          {pathD && (
+            <path
+              d={pathD}
+              fill="none"
+              stroke={color}
+              strokeWidth={2}
+              strokeLinecap="round"
+            />
+          )}
+
+          {validPoints.map((point) => {
+            if (point.value === null) return null;
+            const x = getX(point.date);
+            const y = getY(point.value);
+            return (
+              <circle
+                key={point.date.toISOString()}
+                cx={x}
+                cy={y}
+                r={3.5}
+                fill={color}
+              />
+            );
+          })}
+
+          {normalized.length > 0 && (
+            <>
+              <text
+                x={PADDING_X}
+                y={CHART_HEIGHT - PADDING_Y + 16}
+                textAnchor="start"
+                className="fill-slate-400 text-xs"
+              >
+                {dateFormatter.format(minDate)}
+              </text>
+              <text
+                x={CHART_WIDTH - PADDING_X}
+                y={CHART_HEIGHT - PADDING_Y + 16}
+                textAnchor="end"
+                className="fill-slate-400 text-xs"
+              >
+                {dateFormatter.format(maxDate)}
+              </text>
+            </>
+          )}
+        </svg>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a scheduled job that generates daily KPI snapshots with mock data for all projects
- allow KPI snapshot listing to filter by date range and expose the new metrics in the API
- create a KPI dashboard tab with date range filters and time-series charts for key logistics metrics

## Testing
- npm run lint (api) *(fails: existing lint errors in repository)*
- npm run lint (web) *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68df0af937108331b18153798408ae91