### PR TITLE
fix(ts): configuración mínima estable (sin NodeNext) + seed aislado

### DIFF
--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -38,5 +38,5 @@ module.exports = {
     { files: ['**/*.js'], rules: { '@typescript-eslint/no-var-requires': 'off' } },
     { files: ['src/tests/**/*'], env: { jest: true } },
   ],
-  ignorePatterns: ['dist/**', 'node_modules/**'],
+  ignorePatterns: ['dist/**', 'node_modules/**', 'prisma/**'],
 };

--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/server.cjs",
     "prisma": "prisma",
     "dev:db:migrate": "prisma migrate dev",
-    "db:seed": "ts-node --esm prisma/seed.ts",
+    "db:seed": "tsx --tsconfig tsconfig.seed.json prisma/seed.ts",
     "migrate:deploy": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev",
     "seed": "npm run db:seed",
@@ -19,7 +19,8 @@
     "format": "prettier --write 'src/**/*.{ts,tsx,js,json}'",
     "test": "jest --coverage",
     "test:e2e": "jest --config jest.e2e.config.ts",
-    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix"
+    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@prisma/client": "5.22.0",
@@ -86,6 +87,6 @@
     "typescript": "^5.3.3"
   },
   "prisma": {
-    "seed": "ts-node --esm prisma/seed.ts"
+    "seed": "tsx --tsconfig tsconfig.seed.json prisma/seed.ts"
   }
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "strict": true,
@@ -11,6 +11,6 @@
     "rootDir": "src",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "prisma/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["dist", "node_modules"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["dist", "node_modules", "prisma"]
 }

--- a/api/tsconfig.seed.json
+++ b/api/tsconfig.seed.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist-seed",
+    "noEmit": false
+  },
+  "include": ["prisma/seed.ts"]
+}


### PR DESCRIPTION
## Summary
- switch the API tsconfig to Bundler module resolution while keeping the build rooted at src and excluding prisma sources
- add a dedicated tsconfig.seed.json so the Prisma seed script can compile outside of the main rootDir and run it through tsx
- tell ESLint to ignore prisma-generated sources to avoid lint noise

## Testing
- npm run typecheck *(fails: numerous pre-existing application type errors surfaced once the new configuration is applied)*
- npm run db:seed *(fails: DATABASE_URL is not configured for Prisma migrations in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df1f5d2db883319713bd72fbe88c8b