### PR TITLE
Align API TypeScript config for NodeNext

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,16 +1,22 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "strict": true,
-    "skipLibCheck": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
     "outDir": "dist",
-    "rootDir": "src",
-    "types": ["node"]
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["dist", "node_modules", "prisma", "src/tests/**"]
+  "include": [
+    "src/**/*.ts",
+    "prisma/**/*.ts",
+    "src/**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
## Summary
- configure the API TypeScript compiler for NodeNext modules and resolution
- expand the root directory and includes to cover Prisma seed files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df40539dd08331933cd49d3294a2ab