### PR TITLE
Fix template resolution and seed runtime for CJS

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -15,3 +15,6 @@ BULL_PREFIX=auditoria
 # NPM_CONFIG_PROXY=http://usuario:password@proxy:8080
 # NPM_CONFIG_HTTPS_PROXY=http://usuario:password@proxy:8080
 # NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
+
+# Ruta del template del informe (acepta file://, absoluta o relativa)
+MODULE_REPORT_TEMPLATE=file:///usr/src/app/dist/templates/module-report.hbs

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -63,6 +63,9 @@ RUN apt-get update \
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
 COPY --from=deps /usr/src/app/prisma ./prisma
+# Crear alias para templates en ruta estable usada por el runtime
+RUN mkdir -p /usr/src/dist && \
+    ln -s /usr/src/app/dist/templates /usr/src/dist/templates
 COPY package*.json ./
 COPY docker-entrypoint.sh ./docker-entrypoint.sh
 

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -eu
 
 if [ -z "${DATABASE_URL:-}" ]; then
@@ -6,16 +6,17 @@ if [ -z "${DATABASE_URL:-}" ]; then
   exit 1
 fi
 
-printf 'Applying database migrations...\n'
+printf '[entrypoint] Applying database migrations...\n'
 until npx prisma migrate deploy >/tmp/prisma-migrate.log 2>&1; do
   cat /tmp/prisma-migrate.log >&2 || true
-  printf 'Database unavailable, retrying in 5 seconds...\n'
+  printf '[entrypoint] Database unavailable, retrying in 5 seconds...\n'
   sleep 5
-  printf 'Re-attempting database migrations...\n'
+  printf '[entrypoint] Re-attempting database migrations...\n'
   rm -f /tmp/prisma-migrate.log
 done
 cat /tmp/prisma-migrate.log >&2 || true
 rm -f /tmp/prisma-migrate.log
-printf 'Database migrations applied successfully.\n'
+printf '[entrypoint] Database migrations applied successfully.\n'
 
+printf '[entrypoint] Starting API...\n'
 exec node dist/server.cjs

--- a/api/package.json
+++ b/api/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/server.cjs",
     "prisma": "prisma",
     "dev:db:migrate": "prisma migrate dev",
-    "db:seed": "tsx --tsconfig tsconfig.seed.json prisma/seed.ts",
+    "db:seed": "esbuild prisma/seed.ts --platform=node --bundle --format=cjs --outfile=dist/prisma/seed.cjs && node dist/prisma/seed.cjs",
     "migrate:deploy": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev",
     "seed": "npm run db:seed",
@@ -88,6 +88,6 @@
     "typescript": "5.3.3"
   },
   "prisma": {
-    "seed": "tsx --tsconfig tsconfig.seed.json prisma/seed.ts"
+    "seed": "esbuild prisma/seed.ts --platform=node --bundle --format=cjs --outfile=dist/prisma/seed.cjs && node dist/prisma/seed.cjs"
   }
 }

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 import {
   PrismaClient,
@@ -20,7 +19,8 @@ const runMigrations = (): void => {
     return;
   }
 
-  const apiRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  // seed.cjs se emite en dist/prisma → subir dos niveles hasta la raíz del paquete API
+  const apiRoot = resolve(__dirname, '..', '..');
   console.log('[seed] Ejecutando prisma migrate deploy antes de sembrar datos…');
   try {
     execSync('npx prisma migrate deploy', {

--- a/api/src/utils/resolveAsset.ts
+++ b/api/src/utils/resolveAsset.ts
@@ -1,21 +1,51 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { resolve, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const projectRoot =
-  typeof __dirname !== 'undefined' ? path.resolve(__dirname, '..', '..') : process.cwd();
-const distTemplatesDir = path.resolve(projectRoot, 'dist', 'templates');
-const srcTemplatesDir = path.resolve(projectRoot, 'src', 'templates');
+const projectRoot = typeof __dirname !== 'undefined' ? resolve(__dirname, '..', '..') : process.cwd();
+const distTemplatesDir = resolve(projectRoot, 'dist', 'templates');
+const srcTemplatesDir = resolve(projectRoot, 'src', 'templates');
 
-export const resolveAsset = (relPath: string) => {
-  const distPath = path.resolve(distTemplatesDir, relPath);
+export function resolveModuleReportTemplate(): string {
+  const fromEnv = process.env.MODULE_REPORT_TEMPLATE;
+  if (fromEnv && fromEnv.trim()) {
+    try {
+      if (fromEnv.startsWith('file://')) {
+        return fileURLToPath(fromEnv);
+      }
+      if (isAbsolute(fromEnv)) {
+        return fromEnv;
+      }
+      return resolve(process.cwd(), fromEnv);
+    } catch {
+      // fallback
+    }
+  }
+
+  const prodRoot = '/usr/src/dist';
+  const prodCandidate = resolve(prodRoot, 'templates', 'module-report.hbs');
+  if (existsSync(prodCandidate)) return prodCandidate;
+
+  const distCandidate = resolve(distTemplatesDir, 'module-report.hbs');
+  if (existsSync(distCandidate)) return distCandidate;
+
+  return resolve(srcTemplatesDir, 'module-report.hbs');
+}
+
+export const resolveAsset = (relPath: string): string => {
+  if (relPath === 'module-report.hbs') {
+    return resolveModuleReportTemplate();
+  }
+
+  const distPath = resolve(distTemplatesDir, relPath);
 
   if (process.env.NODE_ENV === 'production') {
     return distPath;
   }
 
-  if (fs.existsSync(distPath)) {
+  if (existsSync(distPath)) {
     return distPath;
   }
 
-  return path.resolve(srcTemplatesDir, relPath);
+  return resolve(srcTemplatesDir, relPath);
 };


### PR DESCRIPTION
## Summary
- copy compiled templates into dist and expose a stable runtime symlink in the Docker image
- make module report template resolution respect env overrides and new dist fallbacks
- bundle the Prisma seed script to CJS and adjust entrypoint logging for consistent migrations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1037ca1f883318dcb4142b2032573