### PR TITLE
feat: ensure puppeteer uses system chromium and add pdf check

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -57,8 +57,43 @@ FROM base AS runner
 ENV NODE_ENV=production
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends curl \
+  && apt-get install -y --no-install-recommends \
+    chromium \
+    ca-certificates \
+    curl \
+    fonts-liberation \
+    fonts-noto-color-emoji \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdrm2 \
+    libgbm1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb-dri3-0 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libxshmfence1 \
+    libxss1 \
+    libxtst6 \
+    xdg-utils \
   && rm -rf /var/lib/apt/lists/*
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+RUN ln -sf /usr/bin/chromium /usr/bin/chromium-browser
 
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -34,6 +34,7 @@ import { fiveSRouter } from './modules/fiveS/five-s.router.js';
 import { hseRouter } from './modules/hse/hse.router.js';
 import { layoutRouter } from './modules/layout/layout.router.js';
 import { routesRouter } from './modules/routes/routes.router.js';
+import { debugRouter } from './modules/debug/debug.router.js';
 
 const appRouter = Router();
 
@@ -71,5 +72,6 @@ appRouter.use('/fiveS', fiveSRouter);
 appRouter.use('/hse', hseRouter);
 appRouter.use('/layout', layoutRouter);
 appRouter.use('/routes', routesRouter);
+appRouter.use('/debug', debugRouter);
 
 export { appRouter };

--- a/api/src/core/browser/puppeteer.ts
+++ b/api/src/core/browser/puppeteer.ts
@@ -1,0 +1,21 @@
+import type { BrowserLaunchArgumentOptions, LaunchOptions } from 'puppeteer';
+
+const DEFAULT_LAUNCH_ARGS = [
+  '--no-sandbox',
+  '--disable-setuid-sandbox',
+  '--disable-dev-shm-usage'
+];
+
+export function createPuppeteerLaunchOptions():
+  | LaunchOptions
+  | (LaunchOptions & BrowserLaunchArgumentOptions) {
+  const executablePath = process.env.PUPPETEER_EXECUTABLE_PATH?.trim();
+
+  return {
+    headless: true,
+    args: DEFAULT_LAUNCH_ARGS,
+    ...(executablePath && executablePath.length > 0 ? { executablePath } : {})
+  };
+}
+
+export const puppeteerLaunchArgs = DEFAULT_LAUNCH_ARGS;

--- a/api/src/modules/debug/debug.router.ts
+++ b/api/src/modules/debug/debug.router.ts
@@ -1,0 +1,67 @@
+import { Router } from 'express';
+import * as puppeteer from 'puppeteer';
+
+import { createPuppeteerLaunchOptions } from '../../core/browser/puppeteer.js';
+
+const debugRouter = Router();
+
+const pdfCheckHtml = `<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Auditoria PDF Check</title>
+    <style>
+      body {
+        font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+        margin: 3rem;
+        color: #0f172a;
+      }
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 0.5rem;
+      }
+      p {
+        margin: 0;
+        font-size: 1rem;
+        color: #475569;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Verificación de PDF</h1>
+    <p>Este documento confirma que Puppeteer puede generar PDFs en este entorno.</p>
+  </body>
+</html>`;
+
+debugRouter.get('/pdf-check', async (_req, res, next) => {
+  let browser: puppeteer.Browser | null = null;
+
+  try {
+    browser = await puppeteer.launch(createPuppeteerLaunchOptions());
+    const page = await browser.newPage();
+
+    await page.setContent(pdfCheckHtml, { waitUntil: 'networkidle0' });
+    await page.emulateMediaType('screen');
+
+    const pdf = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      margin: { top: '16mm', bottom: '18mm', left: '14mm', right: '14mm' }
+    });
+
+    await page.close();
+
+    const browserProcess = browser.process();
+    res.json({
+      ok: true,
+      pdfByteLength: pdf.length,
+      executablePath: browserProcess?.spawnfile ?? null
+    });
+  } catch (error) {
+    next(error);
+  } finally {
+    await browser?.close();
+  }
+});
+
+export { debugRouter };

--- a/api/src/modules/export/report.service.ts
+++ b/api/src/modules/export/report.service.ts
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import * as puppeteer from 'puppeteer';
 import { type ProjectWorkflowState as ProjectWorkflowStateType } from '@prisma/client';
 
+import { createPuppeteerLaunchOptions } from '../../core/browser/puppeteer.js';
 import { prisma } from '../../core/config/db.js';
 import { HttpError } from '../../core/errors/http-error.js';
 
@@ -618,10 +619,7 @@ export async function generateProjectReportPdf(projectId: string) {
 
   let browser: puppeteer.Browser | null = null;
   try {
-    browser = await puppeteer.launch({
-      headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox']
-    });
+    browser = await puppeteer.launch(createPuppeteerLaunchOptions());
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'networkidle0' });
     await page.emulateMediaType('screen');

--- a/api/src/tests/unit/core/browser/puppeteer.spec.ts
+++ b/api/src/tests/unit/core/browser/puppeteer.spec.ts
@@ -1,0 +1,37 @@
+import { createPuppeteerLaunchOptions } from '../../../../core/browser/puppeteer.js';
+
+const ORIGINAL_EXECUTABLE_PATH = process.env.PUPPETEER_EXECUTABLE_PATH;
+
+describe('createPuppeteerLaunchOptions', () => {
+  afterEach(() => {
+    if (ORIGINAL_EXECUTABLE_PATH === undefined) {
+      delete process.env.PUPPETEER_EXECUTABLE_PATH;
+      return;
+    }
+    process.env.PUPPETEER_EXECUTABLE_PATH = ORIGINAL_EXECUTABLE_PATH;
+  });
+
+  it('omits the executable path when the environment variable is not set', () => {
+    delete process.env.PUPPETEER_EXECUTABLE_PATH;
+
+    const options = createPuppeteerLaunchOptions();
+
+    expect(options.headless).toBe(true);
+    expect(options.args).toEqual(
+      expect.arrayContaining([
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage'
+      ])
+    );
+    expect(options).not.toHaveProperty('executablePath');
+  });
+
+  it('uses the executable path from the environment variable when available', () => {
+    process.env.PUPPETEER_EXECUTABLE_PATH = '/usr/bin/chromium';
+
+    const options = createPuppeteerLaunchOptions();
+
+    expect(options.executablePath).toBe('/usr/bin/chromium');
+  });
+});

--- a/scripts/accept.sh
+++ b/scripts/accept.sh
@@ -8,6 +8,7 @@ WAIT_SCRIPT="$ROOT_DIR/scripts/wait-on.sh"
 HEALTH_URL="${ACCEPT_HEALTH_URL:-http://localhost:4000/health}"
 WAIT_TIMEOUT="${ACCEPT_HEALTH_TIMEOUT:-180}"
 WAIT_INTERVAL="${ACCEPT_HEALTH_INTERVAL:-3}"
+PDF_CHECK_URL="${ACCEPT_PDF_CHECK_URL:-http://localhost:4000/api/debug/pdf-check}"
 
 info() {
   printf '\n[accept] %s\n' "$*"
@@ -59,6 +60,14 @@ info "Waiting for API health at $HEALTH_URL"
 
 info "Fetching API health"
 curl --fail --show-error --silent "$HEALTH_URL"
+
+info "Checking PDF generation at $PDF_CHECK_URL"
+pdf_check_response="$(curl --fail --show-error --silent "$PDF_CHECK_URL")"
+if ! grep -q '"pdfByteLength":[1-9]' <<<"$pdf_check_response"; then
+  echo "PDF check did not return a valid payload" >&2
+  echo "$pdf_check_response" >&2
+  exit 1
+fi
 
 info "Building web application"
 run_in_dir "$ROOT_DIR/web" npm run build


### PR DESCRIPTION
## Summary
- install Chromium and related libraries in the API runner image and expose its path to Puppeteer
- centralize Puppeteer launch options so report generation and new debug routes reuse the system browser
- add a PDF health-check endpoint and acceptance script verification to confirm container PDF generation

## Testing
- npm run lint
- npm run test -- --runTestsByPath src/tests/unit/core/browser/puppeteer.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e11fe3db788331bfb174179b4d2afd