### PR TITLE
Fix project listing response and harden API middleware

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -17,6 +17,7 @@
         "bwip-js": "^4.7.0",
         "chart.js": "4.5.0",
         "chartjs-node-canvas": "5.0.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "csv-parse": "^6.1.0",
         "dayjs": "^1.11.10",
@@ -4564,6 +4565,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "dev": "tsx --watch src/server.ts",
     "build": "esbuild src/server.ts --platform=node --bundle --format=cjs --outfile=dist/server.cjs --sourcemap --packages=external",
     "postbuild": "mkdir -p dist/templates && cp -R src/templates/*.hbs dist/templates/",
     "start": "node dist/server.cjs",
@@ -32,6 +32,7 @@
     "bwip-js": "^4.7.0",
     "chart.js": "4.5.0",
     "chartjs-node-canvas": "5.0.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "csv-parse": "^6.1.0",
     "dayjs": "^1.11.10",

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -19,11 +19,13 @@ model Company {
 }
 
 enum ProjectWorkflowState {
-  planificacion
-  recoleccion_datos
-  analisis
-  recomendaciones
-  cierre
+  planificacion       @map("PLANIFICACION")
+  recoleccion_datos   @map("TRABAJO_CAMPO")
+  analisis            @map("INFORME")
+  recomendaciones     @map("RECOMENDACIONES")
+  cierre              @map("CIERRE")
+
+  @@map("EstadoProyecto")
 }
 
 enum ProcessType {

--- a/api/src/core/middleware/auth.ts
+++ b/api/src/core/middleware/auth.ts
@@ -17,12 +17,12 @@ export interface AuthenticatedRequest extends Request {
 
 export const authenticate = async (
   req: AuthenticatedRequest,
-  _res: Response,
+  res: Response,
   next: NextFunction
 ) => {
   const authHeader = req.headers.authorization;
   if (!authHeader) {
-    throw new HttpError(401, 'No autenticado');
+    return res.status(401).json({ title: 'No autenticado' });
   }
 
   const token = authHeader.replace('Bearer ', '');
@@ -46,9 +46,12 @@ export const authenticate = async (
       projects: projectRoles
     };
     await ensureScopedAccess(req);
-    next();
+    return next();
   } catch (error) {
-    throw new HttpError(401, 'Token inválido', error);
+    if (error instanceof HttpError) {
+      return next(error);
+    }
+    return res.status(401).json({ title: 'Token inválido' });
   }
 };
 

--- a/api/src/modules/auth/auth.service.ts
+++ b/api/src/modules/auth/auth.service.ts
@@ -18,10 +18,11 @@ export const authService = {
       throw new HttpError(401, 'Credenciales inválidas');
     }
     const payload = { sub: user.id, email: user.email, role: user.role };
+    const { passwordHash: _passwordHash, ...safeUser } = user;
     return {
       accessToken: signAccessToken(payload),
       refreshToken: signRefreshToken(payload),
-      user
+      user: safeUser
     };
   },
 


### PR DESCRIPTION
## Summary
- wrap the projects endpoint in a safe response envelope with proper auth fallbacks
- harden authentication, server middleware order, and Redis queue initialization failures
- sanitize login payloads and align Prisma enum mapping and tooling dependencies

## Testing
- `npm run lint --prefix api`


------
https://chatgpt.com/codex/tasks/task_e_68e1a8a969908331adbef09116e0d7ac