### PR TITLE
Add cookie-parser type definitions to API

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -45,6 +45,7 @@
       "devDependencies": {
         "@types/archiver": "^5.3.3",
         "@types/bcryptjs": "^2.4.2",
+        "@types/cookie-parser": "^1.4.9",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.12",
@@ -2220,6 +2221,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cookiejar": {

--- a/api/package.json
+++ b/api/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@types/archiver": "^5.3.3",
     "@types/bcryptjs": "^2.4.2",
+    "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
## Summary
- add the @types/cookie-parser dev dependency to provide TypeScript definitions for the API server

## Testing
- ./scripts/accept.sh *(fails: pre-existing web lint/prettier errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b17323048331b2a6d49a8ec4bc11