### PR TITLE
Fix lint issues in WorkflowPanel and TimeSeriesChart

### DIFF
--- a/web/src/modules/projects/WorkflowPanel.tsx
+++ b/web/src/modules/projects/WorkflowPanel.tsx
@@ -71,9 +71,12 @@ export default function WorkflowPanel({ projectId }: { projectId: string }) {
           `${API_BASE}/process-assets/${projectId}`,
           { headers }
         );
-        const workflowResponse = await fetch(`${API_BASE}/workflow/${projectId}`, {
-          headers,
-        });
+        const workflowResponse = await fetch(
+          `${API_BASE}/workflow/${projectId}`,
+          {
+            headers,
+          }
+        );
 
         const assets: ProcessAsset[] = processAssetsResponse.ok
           ? ((await processAssetsResponse.json()) as ProcessAsset[])
@@ -83,7 +86,8 @@ export default function WorkflowPanel({ projectId }: { projectId: string }) {
           throw new Error('No workflow data');
         }
 
-        const workflowJson = (await workflowResponse.json()) as WorkflowResponse;
+        const workflowJson =
+          (await workflowResponse.json()) as WorkflowResponse;
         if (cancelled) return;
         setData(workflowJson);
         setDiagramError(null);
@@ -139,7 +143,7 @@ export default function WorkflowPanel({ projectId }: { projectId: string }) {
           sources.push(async () =>
             typeof workflowDefinition === 'string'
               ? workflowDefinition
-              : workflowDefinition?.xml ?? null
+              : (workflowDefinition?.xml ?? null)
           );
         }
 
@@ -215,9 +219,7 @@ export default function WorkflowPanel({ projectId }: { projectId: string }) {
 
   if (!data) {
     if (diagramError) {
-      return (
-        <div className="p-4 text-sm text-slate-500">{diagramError}</div>
-      );
+      return <div className="p-4 text-sm text-slate-500">{diagramError}</div>;
     }
     return <div className="p-4 text-sm">Cargando flujo…</div>;
   }

--- a/web/src/modules/projects/__tests__/WorkflowPanel.test.tsx
+++ b/web/src/modules/projects/__tests__/WorkflowPanel.test.tsx
@@ -52,7 +52,11 @@ describe('WorkflowPanel', () => {
         return Promise.resolve(
           new Response(
             JSON.stringify([
-              { id: 'asset-1', type: 'BPMN', url: 'https://example.com/asset.bpmn' },
+              {
+                id: 'asset-1',
+                type: 'BPMN',
+                url: 'https://example.com/asset.bpmn',
+              },
             ]),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
           )
@@ -61,16 +65,23 @@ describe('WorkflowPanel', () => {
       if (url === `${API_BASE}/workflow/project-123`) {
         return Promise.resolve(
           new Response(
-            JSON.stringify({ estadoActual: 'enRevision', workflowDefinition: null }),
+            JSON.stringify({
+              estadoActual: 'enRevision',
+              workflowDefinition: null,
+            }),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
           )
         );
       }
       if (url === 'https://example.com/asset.bpmn') {
-        return Promise.resolve(new Response('<asset-diagram />', { status: 200 }));
+        return Promise.resolve(
+          new Response('<asset-diagram />', { status: 200 })
+        );
       }
       if (url.endsWith('/demo/recepcion-demo.bpmn')) {
-        return Promise.resolve(new Response('<demo-diagram />', { status: 200 }));
+        return Promise.resolve(
+          new Response('<demo-diagram />', { status: 200 })
+        );
       }
       throw new Error(`Unhandled fetch: ${url}`);
     });
@@ -80,9 +91,13 @@ describe('WorkflowPanel', () => {
     render(<WorkflowPanel projectId="project-123" />);
 
     await waitFor(() => expect(BpmnConstructorMock).toHaveBeenCalled());
-    await waitFor(() => expect(importXmlMock).toHaveBeenCalledWith('<asset-diagram />'));
+    await waitFor(() =>
+      expect(importXmlMock).toHaveBeenCalledWith('<asset-diagram />')
+    );
     expect(importXmlMock).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText('No hay diagrama disponible')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('No hay diagrama disponible')
+    ).not.toBeInTheDocument();
   });
 
   test('falls back to demo BPMN when no asset exists', async () => {
@@ -98,14 +113,22 @@ describe('WorkflowPanel', () => {
       }
       if (url === `${API_BASE}/workflow/project-empty`) {
         return Promise.resolve(
-          new Response(JSON.stringify({ estadoActual: 'enRevision', workflowDefinition: null }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          })
+          new Response(
+            JSON.stringify({
+              estadoActual: 'enRevision',
+              workflowDefinition: null,
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
         );
       }
       if (url.endsWith('/demo/recepcion-demo.bpmn')) {
-        return Promise.resolve(new Response('<demo-diagram />', { status: 200 }));
+        return Promise.resolve(
+          new Response('<demo-diagram />', { status: 200 })
+        );
       }
       throw new Error(`Unhandled fetch: ${url}`);
     });
@@ -114,8 +137,12 @@ describe('WorkflowPanel', () => {
 
     render(<WorkflowPanel projectId="project-empty" />);
 
-    await waitFor(() => expect(importXmlMock).toHaveBeenCalledWith('<demo-diagram />'));
-    expect(screen.queryByText('No hay diagrama disponible')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(importXmlMock).toHaveBeenCalledWith('<demo-diagram />')
+    );
+    expect(
+      screen.queryByText('No hay diagrama disponible')
+    ).not.toBeInTheDocument();
   });
 
   test('shows message and emits toast when BPMN cannot be loaded', async () => {
@@ -131,10 +158,16 @@ describe('WorkflowPanel', () => {
       }
       if (url === `${API_BASE}/workflow/project-broken`) {
         return Promise.resolve(
-          new Response(JSON.stringify({ estadoActual: 'enRevision', workflowDefinition: null }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          })
+          new Response(
+            JSON.stringify({
+              estadoActual: 'enRevision',
+              workflowDefinition: null,
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
         );
       }
       if (url.endsWith('/demo/recepcion-demo.bpmn')) {


### PR DESCRIPTION
## Summary
- wrap the time series chart coordinate helpers in `useCallback` and memoize min/max dates to satisfy lint rules
- apply Prettier formatting fixes to `WorkflowPanel` and its tests to clear lint errors

## Testing
- ./scripts/accept.sh *(fails at database migration step due to missing `.env`)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b42ebd6883318bae8bef7e9d9e78