### PR TITLE
Fix module report template resolution fallback

### DIFF
--- a/api/src/tests/unit/startup-assets.spec.ts
+++ b/api/src/tests/unit/startup-assets.spec.ts
@@ -5,6 +5,7 @@ import { resolveAsset } from '@/utils/resolveAsset';
 
 describe('startup assets', () => {
   const originalEnv = process.env.NODE_ENV;
+  const originalTemplateEnv = process.env.MODULE_REPORT_TEMPLATE;
 
   beforeAll(() => {
     process.env.NODE_ENV = 'production';
@@ -25,9 +26,24 @@ describe('startup assets', () => {
 
   afterAll(() => {
     process.env.NODE_ENV = originalEnv;
+    process.env.MODULE_REPORT_TEMPLATE = originalTemplateEnv;
   });
 
   it('ensures module-report template is available in production mode', () => {
     expect(fs.existsSync(resolveAsset('module-report.hbs'))).toBe(true);
+  });
+
+  it('falls back to bundled template when env path is invalid', () => {
+    process.env.MODULE_REPORT_TEMPLATE = 'file:///nonexistent/path/module-report.hbs';
+
+    const resolved = resolveAsset('module-report.hbs');
+    const expected = path.resolve(
+      process.cwd(),
+      'src',
+      'templates',
+      'module-report.hbs'
+    );
+
+    expect(resolved).toBe(expected);
   });
 });

--- a/api/src/utils/resolveAsset.ts
+++ b/api/src/utils/resolveAsset.ts
@@ -13,13 +13,18 @@ export function resolveModuleReportTemplate(): string {
   const fromEnv = process.env.MODULE_REPORT_TEMPLATE;
   if (fromEnv && fromEnv.trim()) {
     try {
+      let candidate: string;
       if (fromEnv.startsWith('file://')) {
-        return fileURLToPath(fromEnv);
+        candidate = fileURLToPath(fromEnv);
+      } else if (isAbsolute(fromEnv)) {
+        candidate = fromEnv;
+      } else {
+        candidate = resolve(process.cwd(), fromEnv);
       }
-      if (isAbsolute(fromEnv)) {
-        return fromEnv;
+
+      if (existsSync(candidate)) {
+        return candidate;
       }
-      return resolve(process.cwd(), fromEnv);
     } catch {
       // fallback
     }


### PR DESCRIPTION
## Summary
- ensure MODULE_REPORT_TEMPLATE env overrides are only used when the target file exists
- add a regression test verifying the module report template falls back to the bundled asset

## Testing
- npm test -- --runTestsByPath src/tests/unit/startup-assets.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1b680df608331ac08f267beb10b82