### PR TITLE
fix: wrap module report template assignment

### DIFF
--- a/api/src/tests/unit/startup-assets.spec.ts
+++ b/api/src/tests/unit/startup-assets.spec.ts
@@ -34,7 +34,8 @@ describe('startup assets', () => {
   });
 
   it('falls back to bundled template when env path is invalid', () => {
-    process.env.MODULE_REPORT_TEMPLATE = 'file:///nonexistent/path/module-report.hbs';
+    process.env.MODULE_REPORT_TEMPLATE =
+      'file:///nonexistent/path/module-report.hbs';
 
     const resolved = resolveAsset('module-report.hbs');
     const expected = path.resolve(


### PR DESCRIPTION
## Summary
- reformat the module report template env assignment to match Prettier formatting

## Testing
- npm --prefix api run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2f61d52048331bec950b832c0ee13