### PR TITLE
Disable Express ETag and enforce no-cache headers

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -26,12 +26,13 @@ import { pdfCheck } from './routes/debug/pdf-check';
 
 const app = express();
 
+app.set('etag', false);
+
 const resolvedAppEnv =
   process.env.APP_ENV ?? process.env.NODE_ENV ?? env.nodeEnv ?? 'development';
 const isDev = resolvedAppEnv !== 'production';
 
 if (isDev) {
-  app.set('etag', false);
   app.use(noCacheDevMiddleware);
 }
 
@@ -125,6 +126,13 @@ app.use(
   })
 );
 app.use(globalRateLimiter);
+
+app.use((_, res, next) => {
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
+  next();
+});
 
 app.get(['/health', '/api/health'], (_req, res) => res.json({ ok: true }));
 app.get('/metrics', async (_req, res) => {


### PR DESCRIPTION
## Summary
- disable Express generated ETag headers for the API
- add a global middleware to mark API responses as non-cacheable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e534200df08331ab087de4c0ff4f07