### PR TITLE
Fix CORS preflight handling for login endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Suite full-stack para gestionar auditorías operacionales multiempresa. El proye
 20. [Licencia](#licencia)
 21. [Getting Started](#getting-started)
 22. [Verification](#verification)
-23. [Development notes](#development-notes)
-24. [🛠 Troubleshooting](#-troubleshooting)
+23. [Verificación CORS](#verificación-cors)
+24. [Development notes](#development-notes)
+25. [🛠 Troubleshooting](#-troubleshooting)
 
 ## Visión general
 
@@ -394,6 +395,31 @@ curl -v http://localhost:4000/api/debug/pdf-check -o /tmp/test.pdf
 head -c 5 /tmp/test.pdf   # Debe imprimir: %PDF-
 file /tmp/test.pdf        # Debe decir: PDF document, version 1.x
 ```
+
+## Verificación CORS
+
+Comprueba que las cabeceras del preflight y la llamada real respondan como espera el navegador:
+
+```bash
+# Preflight
+curl -i -X OPTIONS http://localhost:4000/api/auth/login \
+  -H 'Origin: http://localhost:8080' \
+  -H 'Access-Control-Request-Method: POST' \
+  -H 'Access-Control-Request-Headers: authorization,cache-control,content-type,pragma'
+
+# Llamada real (ajusta credenciales)
+curl -i http://localhost:4000/api/auth/login \
+  -H 'Origin: http://localhost:8080' \
+  -H 'Content-Type: application/json' \
+  --data '{"email":"admin@demo.com","password":"demo"}'
+```
+
+Checklist post-fix para limpiar el estado del navegador:
+
+- Borrar Local/Session Storage del origen http://localhost:8080
+- Hard reload (Ctrl+F5)
+- Desactivar cualquier Service Worker en dev
+- Si no se usan cookies, quitar `withCredentials` en el cliente; si se usan, mantenerlo y no usar `*` como origin.
 
 ## Development notes
 

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,1 +1,22 @@
-import './server';
+import cors from 'cors';
+
+import { app, startServer } from './server';
+
+app.use(
+  cors({
+    origin: ['http://localhost:8080'],
+    methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'Cache-Control',
+      'Pragma',
+      'X-Requested-With'
+    ],
+    exposedHeaders: ['Content-Length', 'ETag'],
+    credentials: true,
+    maxAge: 86400
+  })
+);
+
+startServer();


### PR DESCRIPTION
## Summary
- configure the API bootstrap to register Express CORS with the required localhost options before starting the server
- refactor the server entry point to expose a reusable `startServer` helper while keeping existing middleware intact
- document curl verification steps and a browser cache checklist for the CORS fix

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53d63b0c08331851a259907ac79bc