### PR TITLE
Fix caching and CORS for login

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,4 @@
-# URL base de la API consumida por el frontend
-VITE_API_URL=http://localhost:4000/api
+# URL base de la API consumida por el frontend (sin /api al final)
+VITE_API_BASE=http://localhost:4000
+# Compatibilidad con configuraciones antiguas:
+# VITE_API_URL=http://localhost:4000/api

--- a/web/nginx/default.conf
+++ b/web/nginx/default.conf
@@ -1,59 +1,28 @@
-map $http_host $dev_cache_control {
-  default "";
-  ~*^(localhost|127\.0\.0\.1|::1)$ "no-store";
-}
-
-map $http_host $dev_pragma {
-  default "";
-  ~*^(localhost|127\.0\.0\.1|::1)$ "no-cache";
-}
-
 server {
   listen 80;
   server_name localhost;
+  root /usr/share/nginx/html;
+  index index.html;
 
-  root   /usr/share/nginx/html;
-  index  index.html;
-
-  # Evitar respuestas 304 por validación condicional
-  etag off;
-
-  # Ruta exacta HTML raíz
+  # HTML sin caché
   location = / {
+    add_header Cache-Control "no-store" always;
     try_files /index.html =404;
-    if_modified_since off;
+  }
+  location = /index.html {
     add_header Cache-Control "no-store" always;
-    add_header Pragma "no-cache" always;
+    try_files /index.html =404;
   }
 
-  # Cualquier .html directo
-  location ~* \.html$ {
-    if_modified_since off;
-    add_header Cache-Control "no-store" always;
-    add_header Pragma "no-cache" always;
-  }
-
-  # SPA fallback (rutas internas)
-  location / {
-    try_files $uri $uri/ /index.html;
-    if_modified_since off;
-    add_header Cache-Control "no-store" always;
-    add_header Pragma "no-cache" always;
-  }
-
-  # Assets con hash: cache fuerte e inmutable
-  location /assets/ {
-    access_log off;
-    expires 1y;
+  # Assets versionados con caché agresiva
+  location ~* \.(js|css|woff2?|ttf|eot|svg|png|jpg|jpeg|gif|webp|ico)$ {
     add_header Cache-Control "public, max-age=31536000, immutable" always;
     try_files $uri =404;
   }
 
-  # Otros estáticos (moderado)
-  location ~* \.(css|js|woff2?|ttf|eot|svg)$ {
-    access_log off;
-    expires 7d;
-    add_header Cache-Control "public, max-age=604800" always;
-    try_files $uri =404;
+  # Fallback SPA (rutas internas del app)
+  location / {
+    add_header Cache-Control "no-store" always;
+    try_files $uri /index.html;
   }
 }

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,9 +1,8 @@
 // web/src/pages/Login.tsx
-import axios from 'axios';
 import { FormEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import api, { API_BASE_URL } from '../lib/api';
+import api, { login as apiLogin } from '../lib/api';
 import { getErrorMessage } from '../lib/errors';
 import { LAST_PROJECT_KEY, ROLE_KEY, storeTokens } from '../lib/session';
 
@@ -19,17 +18,10 @@ export default function Login() {
     setErr(null);
     setLoading(true);
     try {
-      const r = await axios.post(
-        `${API_BASE_URL}/auth/login`,
-        { email, password },
-        {
-          headers: { 'Content-Type': 'application/json' },
-          withCredentials: true,
-        },
-      );
-      const accessToken = r.data?.accessToken || r.data?.token;
-      const refreshToken = r.data?.refreshToken;
-      const role = r.data?.user?.role;
+      const data = await apiLogin(email, password);
+      const accessToken = data?.accessToken || data?.token;
+      const refreshToken = data?.refreshToken;
+      const role = data?.user?.role;
       if (!accessToken || !refreshToken)
         throw new Error('Respuesta sin tokens');
       storeTokens({ accessToken, refreshToken });


### PR DESCRIPTION
## Summary
- replace the frontend nginx configuration to serve HTML without cache, aggressively cache hashed assets, and keep SPA routing working
- configure the NestJS bootstrap to use Helmet and enable CORS for http://localhost:8080 with the required headers
- update the web API client and login screen to target the new API base URL and rely on bearer tokens instead of cookies

## Testing
- npm run build --prefix web
- npm run build --prefix api *(fails: missing @nestjs/core in the current dependency set)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b3a00fc883319f827f9e3fcd8b8f