### PR TITLE
fix: remove trailing comma in app module

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -6,6 +6,6 @@ import { HealthController } from './health.controller';
 @Module({
   imports: [ConfigModule.forRoot({ isGlobal: true })],
   controllers: [HealthController],
-  providers: [],
+  providers: []
 })
 export class AppModule {}


### PR DESCRIPTION
## Summary
- remove the trailing comma from the providers array in the AppModule configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5c02718448331b21f7c2d60b53d3f