### PR TITLE
style: clean up CORS options formatting

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -24,8 +24,13 @@ async function bootstrap() {
     origin,
     credentials: true,
     methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'Cache-Control', 'Pragma'],
-    exposedHeaders: ['ETag'],
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'Cache-Control',
+      'Pragma'
+    ],
+    exposedHeaders: ['ETag']
   });
 
   const expressInstance = app.getHttpAdapter().getInstance();
@@ -44,7 +49,6 @@ async function bootstrap() {
   await app.listen(port);
   locals.nestBootstrapped = true;
   startBackgroundProcesses();
-  // eslint-disable-next-line no-console
   console.log(`API running on port ${port}`);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- expand the CORS allowedHeaders list to one header per line to match Prettier formatting
- remove the trailing comma from the exposedHeaders entry and delete the unused eslint-disable comment

## Testing
- npm run lint *(fails: import/no-unresolved for Nest dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c119dc6c83318d3bdec688cdca20