### PR TITLE
Fix import order and formatting in API server

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -2,13 +2,13 @@ import 'dotenv/config';
 import 'express-async-errors';
 
 import type { Server } from 'http';
-import type { Express, RequestHandler } from 'express';
 
 import cookieParser from 'cookie-parser';
+import type { Express, RequestHandler } from 'express';
 import express, { json, urlencoded } from 'express';
 import helmet from 'helmet';
-import { pinoHttp } from 'pino-http';
 import { pino } from 'pino';
+import { pinoHttp } from 'pino-http';
 
 import { appRouter } from './app';
 import { env } from './core/config/env';
@@ -193,11 +193,17 @@ const startBackgroundProcesses = (): void => {
         (message.includes('Redis is already connecting') ||
           message.includes('Redis is already connected'))
       ) {
-        logger.warn({ err: error }, 'BullMQ deshabilitado: Redis ya estaba conectado');
+        logger.warn(
+          { err: error },
+          'BullMQ deshabilitado: Redis ya estaba conectado'
+        );
         return;
       }
 
-      logger.error({ err: error }, 'No se pudieron inicializar los workers de la cola');
+      logger.error(
+        { err: error },
+        'No se pudieron inicializar los workers de la cola'
+      );
     });
   } else {
     logger.warn('BullMQ deshabilitado por DISABLE_QUEUES=true');
@@ -224,4 +230,10 @@ const startServer = (): Server => {
   return serverInstance;
 };
 
-export { app, configureApp, ensureHelmet, startBackgroundProcesses, startServer };
+export {
+  app,
+  configureApp,
+  ensureHelmet,
+  startBackgroundProcesses,
+  startServer
+};

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -104,7 +104,7 @@ api.interceptors.response.use(
         originalRequest.baseURL || api.defaults.baseURL || API_ORIGIN;
       const requestUrl = new URL(
         originalRequest.url ?? '',
-        resolvedBase.endsWith('/') ? resolvedBase : `${resolvedBase}/`,
+        resolvedBase.endsWith('/') ? resolvedBase : `${resolvedBase}/`
       );
       requestUrl.searchParams.set('t', String(Date.now()));
       const retriedHeaders = AxiosHeaders.from(originalRequest.headers ?? {});
@@ -164,7 +164,7 @@ api.interceptors.response.use(
     }
 
     return Promise.reject(error);
-  },
+  }
 );
 
 export default api;
@@ -194,7 +194,7 @@ type ApiFetchInit = RequestInit;
 
 export async function apiFetch(
   path: string,
-  init: ApiFetchInit = {},
+  init: ApiFetchInit = {}
 ): Promise<Response> {
   const method = (init.method ?? 'GET').toUpperCase();
   const headers = new Headers(init.headers ?? {});
@@ -233,7 +233,7 @@ export async function apiFetch(
 
 export async function apiFetchJson<T = unknown>(
   path: string,
-  init: ApiFetchInit = {},
+  init: ApiFetchInit = {}
 ): Promise<T> {
   const response = await apiFetch(path, init);
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- reorder API server imports to satisfy import/order lint grouping rules
- format multi-argument logger calls and exported symbols for Prettier compliance
- prettify api client helper to address trailing comma lint errors triggered by repo lint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5c21322888331b7082472de6bacf5