### PR TITLE
Ensure health endpoint bypasses 404 after Nest bootstrap

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -122,13 +122,7 @@ const configureApp = (app: Express): Express => {
   };
 
   app.get('/api/health', respondHealth);
-  app.get('/health', (req, res, next) => {
-    const locals = app.locals as AppLocals;
-    if (locals?.nestBootstrapped) {
-      return next();
-    }
-    return respondHealth(req, res, next);
-  });
+  app.get('/health', respondHealth);
 
   app.get('/metrics', async (_req, res) => {
     res.setHeader('Content-Type', metricsRegistry.contentType);


### PR DESCRIPTION
## Summary
- ensure the Express /health route continues to respond after Nest bootstraps by keeping the express handler active

## Testing
- scripts/accept.sh *(fails: lint cannot resolve Nest dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c62cee648331954ad58a43795da9