### PR TITLE
Fix health check routing after Nest bootstrap

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -117,7 +117,14 @@ const configureApp = (app: Express): Express => {
     next();
   });
 
-  const respondHealth: RequestHandler = (_req, res) => {
+  const respondHealth: RequestHandler = (req, res, next) => {
+    const { nestBootstrapped } = req.app.locals as AppLocals;
+
+    if (nestBootstrapped) {
+      next();
+      return;
+    }
+
     res.json({ ok: true });
   };
 
@@ -134,7 +141,14 @@ const configureApp = (app: Express): Express => {
   app.use('/api/export', reportRouter);
   app.use('/api/surveys', surveysRouter);
   app.get('/api/debug/pdf-check', pdfCheck);
-  app.use((req, res) => {
+  app.use((req, res, next) => {
+    const { nestBootstrapped } = req.app.locals as AppLocals;
+
+    if (nestBootstrapped) {
+      next();
+      return;
+    }
+
     const problem = {
       type: 'https://httpstatuses.com/404',
       title: 'Not Found',


### PR DESCRIPTION
## Summary
- update the Express health endpoint to defer to Nest once the app has finished bootstrapping
- allow the 404 handler to hand off to Nest after bootstrapping so the framework can serve its own routes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5cc4822c08331ae3a1d2a2e750f7b