### PR TITLE
Ensure Express server runs CORS before routing

### DIFF
--- a/api/src/core/config/cors-options.ts
+++ b/api/src/core/config/cors-options.ts
@@ -1,0 +1,11 @@
+import type { CorsOptions } from 'cors';
+
+const defaultOrigin = process.env.FRONTEND_ORIGIN ?? 'http://localhost:8080';
+
+export const corsOptions: CorsOptions = {
+  origin: defaultOrigin,
+  credentials: true,
+  methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'Cache-Control', 'Pragma'],
+  exposedHeaders: ['ETag']
+};

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -7,6 +7,7 @@ import express from 'express';
 import helmet from 'helmet';
 
 import { AppModule } from './app.module';
+import { corsOptions } from './core/config/cors-options';
 import { configureApp, startBackgroundProcesses } from './server';
 
 async function bootstrap() {
@@ -19,19 +20,7 @@ async function bootstrap() {
     { bufferLogs: true }
   );
 
-  const origin = process.env.FRONTEND_ORIGIN ?? 'http://localhost:8080';
-  app.enableCors({
-    origin,
-    credentials: true,
-    methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: [
-      'Content-Type',
-      'Authorization',
-      'Cache-Control',
-      'Pragma'
-    ],
-    exposedHeaders: ['ETag']
-  });
+  app.enableCors(corsOptions);
 
   const expressInstance = app.getHttpAdapter().getInstance();
   const locals = expressInstance.locals as {

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -4,6 +4,7 @@ import 'express-async-errors';
 import type { Server } from 'http';
 
 import cookieParser from 'cookie-parser';
+import cors from 'cors';
 import type { Express, RequestHandler } from 'express';
 import express, { json, urlencoded } from 'express';
 import helmet from 'helmet';
@@ -12,6 +13,7 @@ import { pinoHttp } from 'pino-http';
 
 import { appRouter } from './app';
 import { env } from './core/config/env';
+import { corsOptions } from './core/config/cors-options';
 import { metricsRegistry } from './core/metrics/registry';
 import { globalRateLimiter } from './core/middleware/rate-limit';
 import { noCacheDevMiddleware } from './core/middleware/no-cache-dev';
@@ -109,6 +111,7 @@ const configureApp = (app: Express): Express => {
   app.use(urlencoded({ extended: true }));
   app.use(cookieParser());
   app.use(globalRateLimiter);
+  app.use(cors(corsOptions));
 
   app.use((_, res, next) => {
     res.setHeader('Cache-Control', 'no-store');


### PR DESCRIPTION
## Summary
- add a shared CORS options module that mirrors the Nest bootstrap configuration
- apply the Express cors middleware before API routers and the 404 handler to match the Nest configuration

## Testing
- TS_NODE_TRANSPILE_ONLY=1 JWT_SECRET=secret JWT_REFRESH_SECRET=secret2 npx --yes ts-node -r tsconfig-paths/register -e "import express from 'express'; import request from 'supertest'; import { configureApp } from './src/server'; (async () => { const app = configureApp(express()); const res = await request(app).options('/api/health').set('Origin','http://localhost:3000').set('Access-Control-Request-Method','GET'); console.log(JSON.stringify({ status: res.status, headers: { 'access-control-allow-origin': res.headers['access-control-allow-origin'], 'access-control-allow-methods': res.headers['access-control-allow-methods'], 'access-control-allow-credentials': res.headers['access-control-allow-credentials'], vary: res.headers['vary'] } }, null, 2)); })();"

------
https://chatgpt.com/codex/tasks/task_e_68e5cd8772208331b429647513279092