### PR TITLE
Add no-cache headers to HTML nginx locations

### DIFF
--- a/web/nginx/default.conf
+++ b/web/nginx/default.conf
@@ -11,11 +11,15 @@ server {
 
   location = / {
     add_header Cache-Control "no-store" always;
+    add_header Pragma "no-cache" always;
+    add_header Expires "0" always;
     try_files /index.html =404;
   }
 
   location = /index.html {
     add_header Cache-Control "no-store" always;
+    add_header Pragma "no-cache" always;
+    add_header Expires "0" always;
   }
 
   # Assets con hash: immutable
@@ -32,6 +36,8 @@ server {
 
   location / {
     add_header Cache-Control "no-store" always;
+    add_header Pragma "no-cache" always;
+    add_header Expires "0" always;
     try_files $uri /index.html;
   }
 }


### PR DESCRIPTION
## Summary
- add Pragma and Expires response headers to all HTML-serving nginx locations to complement Cache-Control

## Testing
- docker compose build web *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e5cf70c1088331b294548aee06a486