### PR TITLE
Ensure health endpoint returns OK after Nest boot

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -120,14 +120,7 @@ const configureApp = (app: Express): Express => {
     next();
   });
 
-  const respondHealth: RequestHandler = (req, res, next) => {
-    const { nestBootstrapped } = req.app.locals as AppLocals;
-
-    if (nestBootstrapped) {
-      next();
-      return;
-    }
-
+  const respondHealth: RequestHandler = (_req, res) => {
     res.json({ ok: true });
   };
 


### PR DESCRIPTION
## Summary
- return `{ ok: true }` from the Express health handler without delegating to later middleware so the response stays consistent after Nest starts

## Testing
- curl http://localhost:4000/health (before Nest boot)
- curl http://localhost:4000/health (after Nest boot)


------
https://chatgpt.com/codex/tasks/task_e_68e5d2653b8c83318aac0e5ad7215405