### PR TITLE
Fix auth preflight CORS handling

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -110,8 +110,12 @@ const configureApp = (app: Express): Express => {
   app.use(json());
   app.use(urlencoded({ extended: true }));
   app.use(cookieParser());
+
+  const corsMiddleware = cors(corsOptions);
+  app.use(corsMiddleware);
+  app.options('*', corsMiddleware);
+
   app.use(globalRateLimiter);
-  app.use(cors(corsOptions));
 
   app.use((_, res, next) => {
     res.setHeader('Cache-Control', 'no-store');

--- a/api/src/tests/unit/server.cors.spec.ts
+++ b/api/src/tests/unit/server.cors.spec.ts
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import type { Express } from 'express';
+import express from 'express';
+
+describe('server CORS configuration', () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    const serverModule = await import('../../server');
+    app = serverModule.configureApp(express());
+  });
+
+  it('responds with the configured CORS headers for auth preflight requests', async () => {
+    const origin = process.env.FRONTEND_ORIGIN ?? 'http://localhost:8080';
+
+    const response = await request(app)
+      .options('/api/auth/login')
+      .set('Origin', origin)
+      .set('Access-Control-Request-Method', 'POST');
+
+    expect(response.status).toBe(204);
+    expect(response.headers['access-control-allow-origin']).toBe(origin);
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary
- register the shared CORS middleware once for the Express server and handle OPTIONS requests globally
- add a unit test that asserts the auth login preflight response exposes the configured headers

## Testing
- npx jest --config jest.config.ts src/tests/unit/server.cors.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5d33c99bc8331aa961e1c2d175964