### PR TITLE
Ensure legacy HTML responses disable caching

### DIFF
--- a/web/nginx/default.conf
+++ b/web/nginx/default.conf
@@ -22,6 +22,13 @@ server {
     add_header Expires "0" always;
   }
 
+  location = /200.html {
+    add_header Cache-Control "no-store" always;
+    add_header Pragma "no-cache" always;
+    add_header Expires "0" always;
+    try_files /index.html =404;
+  }
+
   # Assets con hash: immutable
   location ~* \.(js|css|woff2?|ttf|eot|svg)$ {
     add_header Cache-Control "public, max-age=31536000, immutable" always;


### PR DESCRIPTION
## Summary
- add a dedicated location for 200.html and ensure it emits legacy no-cache headers

## Testing
- not run (Docker is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e5d4578e5c833191ee0a3b41031550